### PR TITLE
fix(nix): wrap executable to keep other files in derivation

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -4,6 +4,7 @@
 , fetchFromGitLab
 , nodePackages
 , meson
+, makeWrapper
 , pkg-config
 , ninja
 , gobject-introspection
@@ -20,7 +21,6 @@
 , libsoup_3
 , libnotify
 , pam
-, writeShellScriptBin
 , extraPackages ? [ ]
 , version ? "git"
 , buildTypes ? false
@@ -33,8 +33,8 @@ let
     rev = "8e7a5a4c3e51007ce6579292642517e3d3eb9c50";
     sha256 = "sha256-FosJwgTCp6/EI6WVbJhPisokRBA6oT0eo7d+Ya7fFX8=";
   };
-
-  astal = stdenv.mkDerivation rec {
+in
+  stdenv.mkDerivation rec {
     pname = "astal";
     inherit version;
 
@@ -66,6 +66,11 @@ let
       patchShebangs post_install.sh
     '';
 
+    postInstall = ''
+      wrapProgram $out/bin/astal \
+        --prefix LD_PRELOAD : ${gtk4-layer-shell}/lib/libgtk4-layer-shell.so
+    '';
+
     nativeBuildInputs = [
       pkg-config
       meson
@@ -73,6 +78,7 @@ let
       nodePackages.typescript
       wrapGAppsHook
       gobject-introspection
+      makeWrapper
     ];
 
     buildInputs = [
@@ -97,7 +103,4 @@ let
       license = licenses.gpl3;
       meta.maintainers = [ lib.maintainers.Aylur ];
     };
-  };
-in writeShellScriptBin "astal" ''
-  LD_PRELOAD=${gtk4-layer-shell}/lib/libgtk4-layer-shell.so ${astal}/bin/astal $@
-''
+  }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -96,6 +96,8 @@ in
       pam
     ] ++ extraPackages;
 
+    outputs = [ "out" "lib" ];
+
     meta = with lib; {
       description = "JavaScript/TypeScript framework for creating Linux Desktops";
       homepage = "https://github.com/Aylur/Astal";


### PR DESCRIPTION
I noticed that types weren't getting symlinked properly, because we were only getting the reference to the `writeShellScriptBin` and we would lose all the other files such as `lib` and `share` in the actual derivation.

However, with this fix, having both ags and astal home-manager modules enabled gives collisions between the 2 derivations. I could fix that by using `pkgs.lowPrio` on one of the derivation but it doesn't feel right.