### PR TITLE
nix: initial cleanup; build & deploy docs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,10 +2,10 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
 
 permissions:
-  contents: read
+  contents: read-write
   pages: write
   id-token: write
 
@@ -27,6 +27,17 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+        with:
+          logger: pretty
+
+      - name: Build Documentation
+        run: |
+          nix build .#docs --print-build-logs
+
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: JamesIves/github-pages-deploy-action@v4 # GH's deploy action does not support target dir
+        with:
+          folder: result/libastal

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -46,11 +46,11 @@
     authors ? "Aylur",
     dependencies ? {},
     out ? "libastal/${name}",
-  } @ args:
+  }:
     genRefForPkg {
-      name = "Astal${args.namespace}";
+      name = "Astal${namespace}";
       pkg = name;
-      outPath = args.out;
+      outPath = out;
       metaData = {
         library = {
           inherit description authors;
@@ -71,7 +71,7 @@ in
     name = "library-reference";
     src = builtins.path {
       name = "library-reference-src";
-      src = ./.;
+      path = ./.;
     };
 
     nativeBuildInputs = [

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -1,0 +1,53 @@
+{
+  version,
+  lib,
+  stdenv,
+  glib,
+  wrapGAppsHook,
+  gobject-introspection,
+  meson,
+  pkg-config,
+  ninja,
+  vala,
+  wayland,
+  ...
+}: let
+  inherit (builtins) path;
+  inherit (lib.sources) cleanSource;
+  inherit (lib.lists) concatLists;
+  inherit (lib.strings) replaceStrings readFile;
+
+  getVersionFromFile = file: (replaceStrings ["\n"] [""] (readFile file));
+
+  mkAstalPkg = {
+    pname,
+    src,
+    buildInputs ? [],
+  } @ args:
+    stdenv.mkDerivation {
+      inherit pname version;
+      src = path {
+        name = "${pname}-${version}";
+        src = cleanSource args.src;
+      };
+
+      nativeBuildInputs = [
+        wrapGAppsHook
+        gobject-introspection
+        meson
+        pkg-config
+        ninja
+        vala
+        wayland
+      ];
+
+      buildInputs = concatLists [
+        [glib]
+        args.buildInputs
+      ];
+
+      outputs = ["out" "dev"];
+    };
+in {
+  inherit getVersionFromFile mkAstalPkg;
+}

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -23,12 +23,12 @@
     pname,
     src,
     buildInputs ? [],
-  } @ args:
+  }:
     stdenv.mkDerivation {
       inherit pname version;
       src = path {
         name = "${pname}-${version}";
-        src = cleanSource args.src;
+        path = cleanSource src;
       };
 
       nativeBuildInputs = [
@@ -43,7 +43,7 @@
 
       buildInputs = concatLists [
         [glib]
-        args.buildInputs
+        buildInputs
       ];
 
       outputs = ["out" "dev"];


### PR DESCRIPTION
Cleans up most helper functions to avoid ambiguity in function argument order & argument names. The documentation derivation still needs more cleaning (lib is a *terrible* name to give to a helper function) but I ran out of time for today.

Also builds the docs with nix, and deploys via GH actions. Should be pretty straightforward, but untested. Website builds fine with Nix, and the result dir can be server with Python's http - everything is in order.