### PR TITLE
example: use gicon for tray

### DIFF
--- a/examples/js/simple-bar/widget/Bar.tsx
+++ b/examples/js/simple-bar/widget/Bar.tsx
@@ -22,20 +22,7 @@ function SysTray() {
                 onClickRelease={self => {
                     menu?.popup_at_widget(self, Gdk.Gravity.SOUTH, Gdk.Gravity.NORTH, null)
                 }}>
-                <icon
-                    setup={self => {
-                        if (item.iconName) self.icon = item.iconName
-                        if (item.iconPixbuf) self.pixbuf = item.iconPixbuf
-
-                        self.hook(item, "notify::icon-name", () => {
-                            self.icon = item.iconName
-                        })
-
-                        self.hook(item, "notify::icon-pixbuf", () => {
-                            self.pixbuf = item.iconPixbuf
-                        })
-                    }}
-                />
+                <icon g_icon={bind(item, "gicon")}/>
             </button>
         }))}
     </box>


### PR DESCRIPTION
changes the js example to use gicon instead of icon-name/pixbuf for the systemtray.