### PR TITLE
Fix flake for river

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,7 @@
           ninja
           vala
           wayland
+          wayland-scanner
         ];
         propagatedBuildInputs = [pkgs.glib] ++ inputs;
         pname = name;


### PR DESCRIPTION
the wayland package used to propagate the wayland-scanner binary, this is now fixed and wayland-scanner needs to be manually included