### PR TITLE
core: fix astalified container not removing children

### DIFF
--- a/core/gjs/src/astalify.ts
+++ b/core/gjs/src/astalify.ts
@@ -19,7 +19,9 @@ function setChildren(parent: Gtk.Widget, children: Gtk.Widget[]) {
         if (ch)
             parent.remove(ch)
     }
-    else if (parent instanceof Gtk.Container) {
+    else if (parent instanceof Gtk.container &&
+            !(parent instanceof Astal.Box ||
+              parent instanceof Astal.Stack)) {
         for(const ch of parent.get_children())
 	          parent.remove(ch)
 	  }

--- a/core/gjs/src/astalify.ts
+++ b/core/gjs/src/astalify.ts
@@ -24,7 +24,7 @@ function setChildren(parent: Gtk.Widget, children: Gtk.Widget[]) {
               parent instanceof Astal.Stack)) {
         for(const ch of parent.get_children())
 	          parent.remove(ch)
-	  }
+    }
 
     // TODO: add more container types
     if (parent instanceof Astal.Box) {

--- a/core/gjs/src/astalify.ts
+++ b/core/gjs/src/astalify.ts
@@ -19,6 +19,10 @@ function setChildren(parent: Gtk.Widget, children: Gtk.Widget[]) {
         if (ch)
             parent.remove(ch)
     }
+    else if (parent instanceof Gtk.Container) {
+        for(const ch of parent.get_children())
+	          parent.remove(ch)
+	  }
 
     // TODO: add more container types
     if (parent instanceof Astal.Box) {

--- a/core/lua/astal/widget.lua
+++ b/core/lua/astal/widget.lua
@@ -60,6 +60,12 @@ local function set_children(parent, children)
         if rm ~= nil then
             parent:remove(rm)
         end
+    elseif Gtk.Container:is_type_of(parent) and
+           !(Astal.Box:is_type_of(parent) or
+             Astal.Stack:is_type_of(parent)) then
+        for _, ch in ipairs(parent:get_children()) do
+            parent:remove(ch)
+        end
     end
 
     -- TODO: add more container types


### PR DESCRIPTION
If using astalify on a widget inheriting from container and binding the children, will result in new children being added by the bind, but the old ones are not removed. This PR fixes that.