### PR TITLE
Updated the library documentation URLs in the README of the bar examples.

### DIFF
--- a/examples/js/simple-bar/README.md
+++ b/examples/js/simple-bar/README.md
@@ -4,10 +4,10 @@
 
 A simple bar for Hyprland using
 
-- [Audio library](https://aylur.github.io/astal/libraries/audio).
-- [Battery library](https://aylur.github.io/astal/libraries/battery).
-- [Hyprland library](https://aylur.github.io/astal/libraries/hyprland).
-- [Mpris library](https://aylur.github.io/astal/libraries/mpris).
-- [Network library](https://aylur.github.io/astal/libraries/network).
-- [Tray library](https://aylur.github.io/astal/libraries/tray).
-- [WirePlumber library](https://aylur.github.io/astal/libraries/wireplumber).
+- [Audio library](https://aylur.github.io/astal/guide/libraries/audio).
+- [Battery library](https://aylur.github.io/astal/guide/libraries/battery).
+- [Hyprland library](https://aylur.github.io/astal/guide/libraries/hyprland).
+- [Mpris library](https://aylur.github.io/astal/guide/libraries/mpris).
+- [Network library](https://aylur.github.io/astal/guide/libraries/network).
+- [Tray library](https://aylur.github.io/astal/guide/libraries/tray).
+- [WirePlumber library](https://aylur.github.io/astal/guide/libraries/wireplumber).

--- a/examples/lua/simple-bar/README.md
+++ b/examples/lua/simple-bar/README.md
@@ -4,11 +4,11 @@
 
 A simple bar for Hyprland using
 
-- [Audio library](https://aylur.github.io/astal/libraries/audio).
-- [Battery library](https://aylur.github.io/astal/libraries/battery).
-- [Hyprland library](https://aylur.github.io/astal/libraries/hyprland).
-- [Mpris library](https://aylur.github.io/astal/libraries/mpris).
-- [Network library](https://aylur.github.io/astal/libraries/network).
-- [Tray library](https://aylur.github.io/astal/libraries/tray).
-- [WirePlumber library](https://aylur.github.io/astal/libraries/wireplumber).
+- [Audio library](https://aylur.github.io/astal/guide/libraries/audio).
+- [Battery library](https://aylur.github.io/astal/guide/libraries/battery).
+- [Hyprland library](https://aylur.github.io/astal/guide/libraries/hyprland).
+- [Mpris library](https://aylur.github.io/astal/guide/libraries/mpris).
+- [Network library](https://aylur.github.io/astal/guide/libraries/network).
+- [Tray library](https://aylur.github.io/astal/guide/libraries/tray).
+- [WirePlumber library](https://aylur.github.io/astal/guide/libraries/wireplumber).
 - [dart-sass](https://sass-lang.com/dart-sass/) as the css precompiler

--- a/examples/py/simple-bar/README.md
+++ b/examples/py/simple-bar/README.md
@@ -4,11 +4,11 @@
 
 A simple bar for Hyprland using
 
-- [Audio library](https://aylur.github.io/astal/libraries/audio).
-- [Battery library](https://aylur.github.io/astal/libraries/battery).
-- [Hyprland library](https://aylur.github.io/astal/libraries/hyprland).
-- [Mpris library](https://aylur.github.io/astal/libraries/mpris).
-- [Network library](https://aylur.github.io/astal/libraries/network).
-- [Tray library](https://aylur.github.io/astal/libraries/tray).
-- [WirePlumber library](https://aylur.github.io/astal/libraries/wireplumber).
+- [Audio library](https://aylur.github.io/astal/guide/libraries/audio).
+- [Battery library](https://aylur.github.io/astal/guide/libraries/battery).
+- [Hyprland library](https://aylur.github.io/astal/guide/libraries/hyprland).
+- [Mpris library](https://aylur.github.io/astal/guide/libraries/mpris).
+- [Network library](https://aylur.github.io/astal/guide/libraries/network).
+- [Tray library](https://aylur.github.io/astal/guide/libraries/tray).
+- [WirePlumber library](https://aylur.github.io/astal/guide/libraries/wireplumber).
 - [dart-sass](https://sass-lang.com/dart-sass/) as the css precompiler

--- a/examples/vala/simple-bar/README.md
+++ b/examples/vala/simple-bar/README.md
@@ -4,11 +4,11 @@
 
 A simple bar for Hyprland using
 
-- [Audio library](https://aylur.github.io/astal/libraries/audio).
-- [Battery library](https://aylur.github.io/astal/libraries/battery).
-- [Hyprland library](https://aylur.github.io/astal/libraries/hyprland).
-- [Mpris library](https://aylur.github.io/astal/libraries/mpris).
-- [Network library](https://aylur.github.io/astal/libraries/network).
-- [Tray library](https://aylur.github.io/astal/libraries/tray).
-- [WirePlumber library](https://aylur.github.io/astal/libraries/wireplumber).
+- [Audio library](https://aylur.github.io/astal/guide/libraries/audio).
+- [Battery library](https://aylur.github.io/astal/guide/libraries/battery).
+- [Hyprland library](https://aylur.github.io/astal/guide/libraries/hyprland).
+- [Mpris library](https://aylur.github.io/astal/guide/libraries/mpris).
+- [Network library](https://aylur.github.io/astal/guide/libraries/network).
+- [Tray library](https://aylur.github.io/astal/guide/libraries/tray).
+- [WirePlumber library](https://aylur.github.io/astal/guide/libraries/wireplumber).
 - [dart-sass](https://sass-lang.com/dart-sass/) as the css precompiler


### PR DESCRIPTION
Seems that the library URLs for these bar examples had the wrong links in the READMEs and was redirecting to a 404. Updated the links for all language examples to redirect to the proper link.