### PR TITLE
check that conn is not null in Hyprland.write_socket() prior to setting output values

### DIFF
--- a/lib/hyprland/hyprland.vala
+++ b/lib/hyprland/hyprland.vala
@@ -158,8 +158,10 @@ public class Hyprland : Object {
         out DataInputStream stream
     ) throws Error {
         conn = connection("socket");
-        conn.output_stream.write(message.data, null);
-        stream = new DataInputStream(conn.input_stream);
+        if (conn != null) {
+            conn.output_stream.write(message.data, null);
+            stream = new DataInputStream(conn.input_stream);
+        }
     }
 
     public string message(string message) {

--- a/lib/hyprland/hyprland.vala
+++ b/lib/hyprland/hyprland.vala
@@ -161,42 +161,40 @@ public class Hyprland : Object {
         if (conn != null) {
             conn.output_stream.write(message.data, null);
             stream = new DataInputStream(conn.input_stream);
+        } else {
+            stream = null;
+            critical("could not write to the Hyprland socket");
         }
     }
 
     public string message(string message) {
-        SocketConnection conn;
-        DataInputStream stream;
+        SocketConnection? conn;
+        DataInputStream? stream;
         try {
             write_socket(message, out conn, out stream);
-            return stream.read_upto("\x04", -1, null, null);
+            if (stream != null && conn != null) {
+                var res = stream.read_upto("\x04", -1, null, null);
+                conn.close(null);
+                return res;
+            }
         } catch (Error err) {
             critical(err.message);
-        } finally {
-            try {
-                if (conn != null)
-                    conn.close(null);
-            } catch (Error err) {
-                critical(err.message);
-            }
         }
         return "";
     }
 
     public async string message_async(string message) {
-        SocketConnection conn;
-        DataInputStream stream;
+        SocketConnection? conn;
+        DataInputStream? stream;
         try {
             write_socket(message, out conn, out stream);
-            return yield stream.read_upto_async("\x04", -1, Priority.DEFAULT, null, null);
+            if (stream != null && conn != null) {
+                var res = yield stream.read_upto_async("\x04", -1, Priority.DEFAULT, null, null);
+                conn.close(null);
+                return res;
+            }
         } catch (Error err) {
             critical(err.message);
-        } finally {
-            try {
-                conn.close(null);
-            } catch (Error err) {
-                critical(err.message);
-            }
         }
         return "";
     }


### PR DESCRIPTION
Previously, output values of `Hyprland.write_socket()` were being set regardless of if `connection("socket")` was returning null. 
This would cause a segfault if `$XDG_RUNTIME_DIR/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket` was not available.

Hyprland behaves strangely, and sometimes killing a large number of windows simultaneously causes the socket to become very briefly unavailable.
Previously, this would have caused a segfault in the astal application. Now, it does not.