### PR TITLE
apps: fix fuzzy search

### DIFF
--- a/lib/apps/apps.vala
+++ b/lib/apps/apps.vala
@@ -8,7 +8,7 @@ public class Apps : Object {
     public bool show_hidden { get; set; }
     public List<weak Application> list { owned get { return _list.copy(); } }
 
-    public int min_score { get; set; default = 0; }
+    public double min_score { get; set; default = 0; }
 
     public double name_multiplier { get; set; default = 2; }
     public double entry_multiplier { get; set; default = 1; }
@@ -61,7 +61,6 @@ public class Apps : Object {
             r += am.executable * executable_multiplier;
         if (include_description)
             r += am.description * description_multiplier;
-
         return r;
     }
 

--- a/lib/apps/fuzzy.vala
+++ b/lib/apps/fuzzy.vala
@@ -1,10 +1,6 @@
 
 namespace AstalApps {
 
-private int max(int a, int b) {
-    return a > b ? a : b;
-}
-
 public int fuzzy_match_string(string pattern, string str) {
     const int unmatched_letter_penalty = -1;
     int score = 100;
@@ -12,14 +8,17 @@ public int fuzzy_match_string(string pattern, string str) {
     if (pattern.length == 0) return score;
     if (str.length < pattern.length) return int.MIN;
 
+    bool found = fuzzy_match_recurse(pattern, str, score, true, out score);
     score += unmatched_letter_penalty * (str.length - pattern.length);
-    score = fuzzy_match_recurse(pattern, str, score, true);
+    
+    if(!found) score = -10;
 
     return score;
 }
 
-private int fuzzy_match_recurse(string pattern, string str, int score, bool first_char) {
-    if (pattern.length == 0) return score;
+private bool fuzzy_match_recurse(string pattern, string str, int score, bool first_char, out int result) {
+    result = score;
+    if (pattern.length == 0) return true;
 
     int match_idx = 0;
     int offset = 0;
@@ -28,16 +27,19 @@ private int fuzzy_match_recurse(string pattern, string str, int score, bool firs
 
     while ((match_idx = str.casefold().substring(offset).index_of_char(search)) >= 0) {
         offset += match_idx;
-        int subscore = fuzzy_match_recurse(
+        int subscore;
+        bool found = fuzzy_match_recurse(
             pattern.substring(1),
             str.substring(offset + 1),
-            compute_score(offset, first_char, str, offset), false);
-        best_score = max(best_score, subscore);
+            compute_score(offset, first_char, str, offset), false, out subscore);
+        if(!found) break;
+        best_score = int.max(best_score, subscore);
         offset++;
     }
-
-    if (best_score == int.MIN) return int.MIN;
-    return score + best_score;
+    
+    if (best_score == int.MIN) return false;
+    result += best_score;
+    return true;
 }
 
 private int compute_score(int jump, bool first_char, string match, int idx) {
@@ -65,7 +67,7 @@ private int compute_score(int jump, bool first_char, string match, int idx) {
         score += first_letter_bonus;
     }
     if (first_char) {
-        score += max(leading_letter_penalty * jump, max_leading_letter_penalty);
+        score += int.max(leading_letter_penalty * jump, max_leading_letter_penalty);
     }
 
     return score;


### PR DESCRIPTION
reduces the penalty if the pattern was not found. This fixes an issue when searching for eg both name and description and results got filtered out when one of them don't match the pattern.