### PR TITLE
hyprland: fix fullscreen enum

### DIFF
--- a/lib/hyprland/client.vala
+++ b/lib/hyprland/client.vala
@@ -73,10 +73,11 @@ public class Client : Object {
     }
 }
 
+[Flags]
 public enum Fullscreen {
     CURRENT = -1,
     NONE = 0,
-    FULLSCREEN = 1,
-    MAXIMIZED = 2,
+    MAXIMIZED = 1,
+    FULLSCREEN = 2,
 }
 }


### PR DESCRIPTION
Closes #57.

Swaps order of `FULLSCREEN` and `MAXIMIZED`, as per the Hyprland wiki. 

Also adds the missing value `MAXIMIZED_AND_FULLSCREEN`. This value is simply called `MAX` in Hyprland, but I thought this name would be more descriptive, suggestions welcome.