### PR TITLE
Add Uncrustify.cfg for formatting

### DIFF
--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -41,11 +41,11 @@ eat_blanks_before_close_brace	= TRUE
 eat_blanks_after_open_brace	= TRUE
 
 
-mod_paren_on_return		= add		# "return 1;" vs "return (1);"
+mod_paren_on_return		= false		# "return 1;" vs "return (1);"
 mod_full_brace_if		= add		# "if (a) a--;" vs "if (a) { a--; }"
 mod_full_brace_for		= add		# "for () a--;" vs "for () { a--; }"
 mod_full_brace_do		= add		# "do a--; while ();" vs "do { a--; } while ();"
-mod_full_brace_while		= add		# "while (a) a--;" vs "while (a) { a--; }"
+mod_full_brace_while	= add		# "while (a) a--;" vs "while (a) { a--; }"
 
 sp_before_byref			= remove
 sp_before_semi			= remove

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -8,9 +8,10 @@ indent_with_tabs		= 0		# 1=indent to level only, 2=indent with tabs
 indent_columns			= output_tab_size
 indent_align_string		= False		# align broken strings
 indent_brace			= 0
-indent_class			= FALSE
+indent_class			= TRUE
 indent_namespace		= FALSE
 indent_member           = 0
+indent_switch_case      = indent_columns
 # How to indent a close parenthesis after a newline.
 #
 #  0: Indent to body level (default)
@@ -66,6 +67,9 @@ mod_full_brace_do		= add		# "do a--; while ();" vs "do { a--; } while ();"
 mod_full_brace_while	= add		# "while (a) a--;" vs "while (a) { a--; }"
 
 # Spacing
+sp_try_brace            = force
+sp_brace_catch          = force # ignore/add/remove/force
+sp_else_brace           = force
 sp_before_byref			= remove
 sp_before_semi			= remove
 sp_paren_paren			= remove	# space between (( and ))

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -7,6 +7,7 @@ indent_columns			= output_tab_size
 indent_align_string		= False		# align broken strings
 indent_brace			= 0
 indent_class			= true
+indent_namespace		= FALSE
 
 nl_start_of_file		= remove
 nl_end_of_file			= force

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -8,10 +8,9 @@ indent_with_tabs		= 0		# 1=indent to level only, 2=indent with tabs
 indent_columns			= output_tab_size
 indent_align_string		= False		# align broken strings
 indent_brace			= 0
-indent_class			= TRUE
+indent_class			= FALSE
 indent_namespace		= FALSE
 indent_member           = 0
-indent_paren_open_brace         = TRUE    # true/false
 # How to indent a close parenthesis after a newline.
 #
 #  0: Indent to body level (default)

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -1,0 +1,105 @@
+newlines                        = LF		# AUTO (default), CRLF, CR, or LF
+
+indent_with_tabs		= 2		# 1=indent to level only, 2=indent with tabs
+input_tab_size			= 8		# original tab size
+output_tab_size			= 3		# new tab size
+indent_columns			= output_tab_size
+indent_align_string		= False		# align broken strings
+indent_brace			= 0
+indent_class			= true
+
+nl_start_of_file		= remove
+nl_end_of_file			= force
+nl_end_of_file_min		= 1
+nl_max				= 4
+nl_before_block_comment		= 2
+nl_after_func_body		= 2
+nl_after_func_proto_group 	= 2
+
+nl_assign_brace			= remove		# "= {" vs "= \n {"
+nl_enum_brace			= remove		# "enum {" vs "enum \n {"
+nl_union_brace			= remove		# "union {" vs "union \n {"
+nl_struct_brace			= remove		# "struct {" vs "struct \n {"
+nl_do_brace			    = remove		# "do {" vs "do \n {"
+nl_if_brace			    = remove		# "if () {" vs "if () \n {"
+nl_for_brace			= remove		# "for () {" vs "for () \n {"
+nl_else_brace			= remove		# "else {" vs "else \n {"
+nl_while_brace			= remove		# "while () {" vs "while () \n {"
+nl_switch_brace			= remove		# "switch () {" vs "switch () \n {"
+nl_var_def_blk_end_func_top	= 1
+nl_before_case			= 1
+nl_fcall_brace			= remove		# "foo() {" vs "foo()\n{"
+nl_fdef_brace			= remove		# "int foo() {" vs "int foo()\n{"
+nl_after_return			= TRUE
+nl_brace_while			= remove
+nl_brace_else			= add           # "} else" vs "} \n else" - cuddled else
+nl_squeeze_ifdef		= TRUE
+
+pos_bool			= trail		# BOOL ops on trailing end
+
+eat_blanks_before_close_brace	= TRUE
+eat_blanks_after_open_brace	= TRUE
+
+
+mod_paren_on_return		= add		# "return 1;" vs "return (1);"
+mod_full_brace_if		= add		# "if (a) a--;" vs "if (a) { a--; }"
+mod_full_brace_for		= add		# "for () a--;" vs "for () { a--; }"
+mod_full_brace_do		= add		# "do a--; while ();" vs "do { a--; } while ();"
+mod_full_brace_while		= add		# "while (a) a--;" vs "while (a) { a--; }"
+
+sp_before_byref			= remove
+sp_before_semi			= remove
+sp_paren_paren			= remove	# space between (( and ))
+sp_return_paren			= remove	# "return (1);" vs "return(1);"
+sp_sizeof_paren			= remove	# "sizeof (int)" vs "sizeof(int)"
+sp_before_sparen		= force		# "if (" vs "if("
+sp_after_sparen			= force		# "if () {" vs "if (){"
+sp_after_cast			= remove	# "(int) a" vs "(int)a"
+sp_inside_braces		= force		# "{ 1 }" vs "{1}"
+sp_inside_braces_struct		= force		# "{ 1 }" vs "{1}"
+sp_inside_braces_enum		= force		# "{ 1 }" vs "{1}"
+sp_inside_paren			= remove
+sp_inside_fparen		= remove
+sp_inside_sparen		= remove
+sp_inside_for			= remove
+sp_inside_square		= remove
+sp_assign			= force
+sp_arith			= force
+sp_bool				= force
+sp_compare			= force
+sp_assign			= force
+sp_after_comma			= force
+sp_func_def_paren		= remove	# "int foo (){" vs "int foo(){"
+sp_func_call_paren		= remove	# "foo (" vs "foo("
+sp_func_proto_paren		= remove	# "int foo ();" vs "int foo();"
+sp_func_class_paren		= remove
+sp_before_angle			= force
+sp_after_angle			= force
+sp_inside_angle			= remove
+sp_sparen_brace			= add
+sp_fparen_brace			= add
+sp_after_ptr_star		= remove
+sp_before_ptr_star		= force
+sp_between_ptr_star		= remove
+
+# align_with_tabs			= TRUE		# use tabs to align
+# align_on_tabstop		= FALSE		# align on tabstops
+# align_enum_equ_span		= 4
+# align_nl_cont			= 1
+# align_var_def_span		= 1
+# align_var_def_thresh	= 12
+# align_var_def_inline	= FALSE
+# align_var_def_colon		= FALSE
+# align_assign_span		= 1
+# align_assign_thresh		= 12
+# align_struct_init_span		= 3
+# align_var_struct_span		= 99
+# align_right_cmt_span		= 3
+# align_pp_define_span		= 3
+# align_pp_define_gap		= 4
+# align_number_right		= TRUE
+# align_typedef_span		= 5
+# align_typedef_gap		= 3
+
+cmt_star_cont			= TRUE
+

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -10,6 +10,7 @@ indent_class			= FALSE
 indent_namespace		= FALSE
 indent_paren_close      = 0
 indent_paren_after_func_def = FALSE
+donot_indent_func_def_close_paren = TRUE
 
 nl_start_of_file		= remove
 nl_end_of_file			= force

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -2,7 +2,7 @@ newlines                = auto
 input_tab_size          = 8
 output_tab_size         = 8
 
-indent_with_tabs		= 2		# 1=indent to level only, 2=indent with tabs
+indent_with_tabs		= 0		# 1=indent to level only, 2=indent with tabs
 indent_columns			= output_tab_size
 indent_align_string		= False		# align broken strings
 indent_brace			= 0

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -8,9 +8,7 @@ indent_align_string		= False		# align broken strings
 indent_brace			= 0
 indent_class			= FALSE
 indent_namespace		= FALSE
-indent_paren_close      = 0
-indent_paren_after_func_def = FALSE
-donot_indent_func_def_close_paren = TRUE
+indent_paren_close      = 2
 
 nl_start_of_file		= remove
 nl_end_of_file			= force

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -8,6 +8,13 @@ indent_align_string		= False		# align broken strings
 indent_brace			= 0
 indent_class			= FALSE
 indent_namespace		= FALSE
+
+# How to indent a close parenthesis after a newline.
+#
+#  0: Indent to body level (default)
+#  1: Align under the open parenthesis
+#  2: Indent to the brace level
+# -1: Preserve original indentation
 indent_paren_close      = 2
 
 nl_start_of_file		= remove

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -1,7 +1,9 @@
+# General
 newlines                = auto
 input_tab_size          = 8
 output_tab_size         = 4
 
+# Indentation
 indent_with_tabs		= 0		# 1=indent to level only, 2=indent with tabs
 indent_columns			= output_tab_size
 indent_align_string		= False		# align broken strings
@@ -17,50 +19,52 @@ indent_member           = 0
 # -1: Preserve original indentation
 indent_paren_close      = 2
 
+# Newline
+nl_start_of_file		    = remove
+nl_end_of_file			    = force
+nl_end_of_file_min		    = 1
+nl_max				        = 4
+nl_before_block_comment		= 2
+nl_after_func_body		    = 2
+nl_after_func_proto_group 	= 2
+nl_assign_brace			    = remove		# "= {" vs "= \n {"
+nl_enum_brace			    = remove		# "enum {" vs "enum \n {"
+nl_union_brace			    = remove		# "union {" vs "union \n {"
+nl_struct_brace			    = remove		# "struct {" vs "struct \n {"
+nl_do_brace			        = remove		# "do {" vs "do \n {"
+nl_if_brace			        = remove		# "if () {" vs "if () \n {"
+nl_for_brace			    = remove		# "for () {" vs "for () \n {"
+nl_else_brace			    = remove		# "else {" vs "else \n {"
+nl_while_brace			    = remove		# "while () {" vs "while () \n {"
+nl_switch_brace			    = remove		# "switch () {" vs "switch () \n {"
+nl_var_def_blk_end_func_top	= 1
+nl_before_case			    = 1
+nl_fcall_brace			    = remove		# "foo() {" vs "foo()\n{"
+nl_fdef_brace			    = remove		# "int foo() {" vs "int foo()\n{"
+nl_after_return			    = TRUE
+nl_brace_while			    = remove
+nl_brace_else			    = add           # "} else" vs "} \n else" - cuddled else
+nl_squeeze_ifdef		    = TRUE
+
+# Positioning
+pos_bool			            = trail		# BOOL ops on trailing end
 # The position of conditional operators, as in the '?' and ':' of
 # 'expr ? stmt : stmt', in wrapped expressions.
 # ARKye03 msg, please don't use trail, it's awful
 pos_conditional                 = break   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
 
-nl_start_of_file		= remove
-nl_end_of_file			= force
-nl_end_of_file_min		= 1
-nl_max				= 4
-nl_before_block_comment		= 2
-nl_after_func_body		= 2
-nl_after_func_proto_group 	= 2
-
-nl_assign_brace			= remove		# "= {" vs "= \n {"
-nl_enum_brace			= remove		# "enum {" vs "enum \n {"
-nl_union_brace			= remove		# "union {" vs "union \n {"
-nl_struct_brace			= remove		# "struct {" vs "struct \n {"
-nl_do_brace			    = remove		# "do {" vs "do \n {"
-nl_if_brace			    = remove		# "if () {" vs "if () \n {"
-nl_for_brace			= remove		# "for () {" vs "for () \n {"
-nl_else_brace			= remove		# "else {" vs "else \n {"
-nl_while_brace			= remove		# "while () {" vs "while () \n {"
-nl_switch_brace			= remove		# "switch () {" vs "switch () \n {"
-nl_var_def_blk_end_func_top	= 1
-nl_before_case			= 1
-nl_fcall_brace			= remove		# "foo() {" vs "foo()\n{"
-nl_fdef_brace			= remove		# "int foo() {" vs "int foo()\n{"
-nl_after_return			= TRUE
-nl_brace_while			= remove
-nl_brace_else			= add           # "} else" vs "} \n else" - cuddled else
-nl_squeeze_ifdef		= TRUE
-
-pos_bool			= trail		# BOOL ops on trailing end
-
+# Eat blanks
 eat_blanks_before_close_brace	= TRUE
-eat_blanks_after_open_brace	= TRUE
+eat_blanks_after_open_brace	    = TRUE
 
-
+# Modifiers
 mod_paren_on_return		= false		# "return 1;" vs "return (1);"
 mod_full_brace_if		= add		# "if (a) a--;" vs "if (a) { a--; }"
 mod_full_brace_for		= add		# "for () a--;" vs "for () { a--; }"
 mod_full_brace_do		= add		# "do a--; while ();" vs "do { a--; } while ();"
 mod_full_brace_while	= add		# "while (a) a--;" vs "while (a) { a--; }"
 
+# Spacing
 sp_before_byref			= remove
 sp_before_semi			= remove
 sp_paren_paren			= remove	# space between (( and ))
@@ -70,18 +74,18 @@ sp_before_sparen		= force		# "if (" vs "if("
 sp_after_sparen			= force		# "if () {" vs "if (){"
 sp_after_cast			= remove	# "(int) a" vs "(int)a"
 sp_inside_braces		= force		# "{ 1 }" vs "{1}"
-sp_inside_braces_struct		= force		# "{ 1 }" vs "{1}"
-sp_inside_braces_enum		= force		# "{ 1 }" vs "{1}"
+sp_inside_braces_struct	= force		# "{ 1 }" vs "{1}"
+sp_inside_braces_enum	= force		# "{ 1 }" vs "{1}"
 sp_inside_paren			= remove
 sp_inside_fparen		= remove
 sp_inside_sparen		= remove
 sp_inside_for			= remove
 sp_inside_square		= remove
-sp_assign			= force
-sp_arith			= force
-sp_bool				= force
-sp_compare			= force
-sp_assign			= force
+sp_assign			    = force
+sp_arith			    = force
+sp_bool				    = force
+sp_compare			    = force
+sp_assign			    = force
 sp_after_comma			= force
 sp_func_def_paren		= remove	# "int foo (){" vs "int foo(){"
 sp_func_call_paren		= remove	# "foo (" vs "foo("
@@ -95,5 +99,7 @@ sp_fparen_brace			= add
 sp_after_ptr_star		= remove
 sp_before_ptr_star		= force
 sp_between_ptr_star		= remove
+
+# Comments
 cmt_star_cont			= TRUE
 

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -61,10 +61,10 @@ eat_blanks_after_open_brace	    = TRUE
 
 # Modifiers
 mod_paren_on_return		= false		# "return 1;" vs "return (1);"
-mod_full_brace_if		= add		# "if (a) a--;" vs "if (a) { a--; }"
-mod_full_brace_for		= add		# "for () a--;" vs "for () { a--; }"
-mod_full_brace_do		= add		# "do a--; while ();" vs "do { a--; } while ();"
-mod_full_brace_while	= add		# "while (a) a--;" vs "while (a) { a--; }"
+mod_full_brace_if		= ignore		# "if (a) a--;" vs "if (a) { a--; }"
+mod_full_brace_for		= ignore		# "for () a--;" vs "for () { a--; }"
+mod_full_brace_do		= ignore		# "do a--; while ();" vs "do { a--; } while ();"
+mod_full_brace_while	= ignore		# "while (a) a--;" vs "while (a) { a--; }"
 
 # Spacing
 sp_try_brace            = force

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -1,110 +1,248 @@
-# General
-newlines                = auto
-input_tab_size          = 8
-output_tab_size         = 4
-
-# Indentation
-indent_with_tabs		= 0		# 1=indent to level only, 2=indent with tabs
-indent_columns			= output_tab_size
-indent_align_string		= False		# align broken strings
-indent_brace			= 0
-indent_class			= TRUE
-indent_namespace		= FALSE
-indent_member           = 0
-indent_switch_case      = indent_columns
-# How to indent a close parenthesis after a newline.
-#
-#  0: Indent to body level (default)
-#  1: Align under the open parenthesis
-#  2: Indent to the brace level
-# -1: Preserve original indentation
-indent_paren_close      = 2
-
-# Newline
-nl_start_of_file		    = remove
-nl_end_of_file			    = force
-nl_end_of_file_min		    = 1
-nl_max				        = 4
-nl_before_block_comment		= 2
-nl_after_func_body		    = 2
-nl_after_func_proto_group 	= 2
-nl_assign_brace			    = remove		# "= {" vs "= \n {"
-nl_enum_brace			    = remove		# "enum {" vs "enum \n {"
-nl_union_brace			    = remove		# "union {" vs "union \n {"
-nl_struct_brace			    = remove		# "struct {" vs "struct \n {"
-nl_do_brace			        = remove		# "do {" vs "do \n {"
-nl_if_brace			        = remove		# "if () {" vs "if () \n {"
-nl_for_brace			    = remove		# "for () {" vs "for () \n {"
-nl_else_brace			    = remove		# "else {" vs "else \n {"
-nl_while_brace			    = remove		# "while () {" vs "while () \n {"
-nl_switch_brace			    = remove		# "switch () {" vs "switch () \n {"
-nl_var_def_blk_end_func_top	= 1
-nl_before_case			    = 1
-nl_namespace_brace          = remove
-nl_class_brace              = remove
-nl_fcall_brace			    = remove		# "foo() {" vs "foo()\n{"
-nl_fdef_brace			    = remove		# "int foo() {" vs "int foo()\n{"
-nl_after_return			    = TRUE
-nl_brace_while			    = remove
-nl_brace_else			    = add           # "} else" vs "} \n else" - cuddled else
-nl_squeeze_ifdef		    = TRUE
-
-# Positioning
-pos_bool			            = trail		# BOOL ops on trailing end
-# The position of conditional operators, as in the '?' and ':' of
-# 'expr ? stmt : stmt', in wrapped expressions.
-pos_conditional                 = break   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
-
-# Eat blanks
-eat_blanks_before_close_brace	= TRUE
-eat_blanks_after_open_brace	    = TRUE
-
-# Modifiers
-mod_paren_on_return		= false		# "return 1;" vs "return (1);"
-mod_full_brace_if		= ignore		# "if (a) a--;" vs "if (a) { a--; }"
-mod_full_brace_for		= ignore		# "for () a--;" vs "for () { a--; }"
-mod_full_brace_do		= ignore		# "do a--; while ();" vs "do { a--; } while ();"
-mod_full_brace_while	= ignore		# "while (a) a--;" vs "while (a) { a--; }"
+# Uncrustify-0.81.0
+# vim: nowrap
 
 # Spacing
-sp_try_brace            = force
-sp_brace_catch          = force # ignore/add/remove/force
-sp_else_brace           = force
-sp_before_byref			= remove
-sp_before_semi			= remove
-sp_paren_paren			= remove	# space between (( and ))
-sp_return_paren			= remove	# "return (1);" vs "return(1);"
-sp_sizeof_paren			= remove	# "sizeof (int)" vs "sizeof(int)"
-sp_before_sparen		= force		# "if (" vs "if("
-sp_after_sparen			= force		# "if () {" vs "if (){"
-sp_after_cast			= remove	# "(int) a" vs "(int)a"
-sp_inside_braces		= force		# "{ 1 }" vs "{1}"
-sp_inside_braces_struct	= force		# "{ 1 }" vs "{1}"
-sp_inside_braces_enum	= force		# "{ 1 }" vs "{1}"
-sp_inside_paren			= remove
-sp_inside_fparen		= remove
-sp_inside_sparen		= remove
-sp_inside_for			= remove
-sp_inside_square		= remove
-sp_assign			    = force
-sp_arith			    = force
-sp_bool				    = force
-sp_compare			    = force
-sp_assign			    = force
-sp_after_comma			= force
-sp_func_def_paren		= remove	# "int foo (){" vs "int foo(){"
-sp_func_call_paren		= remove	# "foo (" vs "foo("
-sp_func_proto_paren		= remove	# "int foo ();" vs "int foo();"
-sp_func_class_paren		= remove
-sp_before_angle			= force
-sp_after_angle			= force
-sp_inside_angle			= remove
-sp_sparen_brace			= add
-sp_fparen_brace			= add
-sp_after_ptr_star		= remove
-sp_before_ptr_star		= force
-sp_between_ptr_star		= remove
+sp_arith                    = force     # around non-assignment symbolic operators ('+', '/', '%', '<<', and so forth)
+sp_assign                   = force     # around assignment operator '=', '+=', etc
+sp_enum_assign              = force     # around assignment '=' in enum
+sp_bool                     = force     # around boolean operators '&&' and '||'
+sp_compare                  = force     # around compare operator '<', '>', '==', etc
+sp_inside_paren             = remove    # inside '(' and ')'
+sp_paren_paren              = remove    # between nested parentheses, i.e. '((' vs. ') )'
+sp_cparen_oparen            = force     # between back-to-back parentheses, i.e. ')(' vs. ') ('
+sp_paren_brace              = force     # between ')' and '{'
+sp_brace_brace              = remove    # between nested braces, i.e. '{{' vs. '{ {'
+sp_before_ptr_star          = remove    # before pointer star '*'
+sp_before_byref             = force     # before a reference sign '&'
+sp_after_type               = force     # between type and word
+sp_angle_paren              = remove    # between '>' and '(' as found in 'new List<byte>(foo);'
+sp_angle_paren_empty        = remove    # between '>' and '()' as found in 'new List<byte>();'
+sp_angle_word               = force     # between '>' and a word as in 'List<byte> m;'
+sp_angle_shift              = remove    # between '>' and '>' in '>>'
+sp_before_sparen            = force     # before '(' of control statements ('if', 'for', 'switch', 'while', etc.)
+sp_inside_sparen            = remove    # inside '(' and ')' of control statements other than 'for'
+sp_inside_for               = ignore    # space inside '(' and ')' of 'for' statements
+sp_sparen_paren             = remove    # between '((' or '))' of control statements
+sp_after_sparen             = force     # after ')' of control statements
+sp_sparen_brace             = force     # between ')' and '{' of control statements
+sp_do_brace_open            = force     # between 'do' and '{'
+sp_brace_close_while        = ignore    # between '}' and 'while'
+sp_before_semi              = remove    # before ';'
+sp_special_semi             = remove    # before empty statement ';' on 'if', 'for' and 'while' example: if (b) <here> ;
+sp_before_semi_for          = remove    # before ';' in non-empty 'for' statements
+sp_before_semi_for_empty    = remove    # before a semicolon of an empty left part of a for
+sp_between_semi_for_empty   = remove    # between the semicolons of an empty middle part of a for
+sp_after_semi               = add       # after ';', except when followed by a comment
+sp_after_semi_for           = force     # after ';' in non-empty 'for' statements
+sp_after_semi_for_empty     = remove    # after the final semicolon of an empty part of a for
+sp_before_square            = remove    # before '[' (except '[]')
+sp_before_vardef_square     = remove    # before '[' for a variable definition
+sp_before_squares           = remove    # space before '[]'
+sp_inside_square            = remove    # inside a non-empty '[' and ']'
+sp_inside_square_empty      = remove    # inside '[]' if empty
+sp_after_comma              = force     # after ',', i.e. 'a,b' vs. 'a, b'
+sp_before_comma             = remove    # before ',', i.e. 'a,b' vs. 'a ,b'
+sp_after_mdatype_commas     = remove    # between ',' and ']' in multidimensional array type like 'int[,,]'
+sp_before_mdatype_commas    = remove    # between '[' and ',' in multidimensional array type like 'int[,,]'
+sp_between_mdatype_commas   = remove    # between ',' in multidimensional array type like 'int[,,]'
+sp_paren_comma              = force     # between an open parenthesis and comma, i.e. '(,' vs. '( ,'
+sp_after_ellipsis           = force     # after the variadic '...' when preceded by a non-punctuator
+sp_before_ellipsis          = force     # before the variadic '...' when preceded by a non-punctuator
+sp_type_ellipsis            = remove    # between a type and '...'
+sp_ptr_type_ellipsis        = ignore    # between a '*' and '...'
+sp_paren_ellipsis           = force     # between ')' and '...'
+sp_byref_ellipsis           = ignore    # between '&&' and '...'
+sp_paren_qualifier          = ignore    # between ')' and a qualifier such as 'const'
+sp_paren_noexcept           = ignore    # between ')' and 'noexcept'
+sp_after_class_colon        = force     # after class ':'
+sp_before_class_colon       = force     # before class ':'
+sp_before_case_colon        = remove    # space before case ':'
+sp_after_cast               = remove    # after C/D cast, i.e. 'cast(int)a' vs. 'cast(int) a' or '(int)a' vs. '(int) a'
+sp_inside_paren_cast        = remove    # inside cast parentheses
+sp_sizeof_paren             = ignore    # between 'sizeof' and '('
+sp_sizeof_ellipsis          = ignore    # between 'sizeof' and '...'
+sp_sizeof_ellipsis_paren    = ignore    # between 'sizeof...' and '('
+sp_ellipsis_parameter_pack  = ignore    # between '...' and a parameter pack
+sp_parameter_pack_ellipsis  = ignore    # between a parameter pack and '...'
+sp_inside_braces_enum       = ignore    # inside enum '{' and '}'
+sp_inside_braces_struct     = ignore    # inside struct/union '{' and '}'
+sp_inside_braces            = force     # inside '{' and '}'
+sp_inside_braces_empty      = remove    # inside '{}'
+sp_type_func                = force     # between return type and function name. A minimum of 1 is forced except for pointer return types
+sp_func_proto_paren         = remove    # between function name and '(' on function declaration
+sp_func_proto_paren_empty   = remove    # between function name and '()' on function declaration if empty
+sp_func_def_paren_empty     = remove    # between function name and '()' on function definition if empty.
+sp_inside_fparens           = ignore    # inside empty function '()'
+sp_inside_fparen            = remove    # inside function '(' and ')'
+sp_square_fparen            = remove    # between ']' and '(' when part of a function call
+sp_fparen_brace             = force     # space between ')' and '{' of function
+sp_fparen_brace_initializer = force     # between ')' and '{' of a function call in object initialization
+sp_func_call_paren          = remove    # between function name and '(' on function calls
+sp_func_class_paren         = remove    # between a constructor/destructor and the open parenthesis
+sp_func_class_paren_empty   = remove    # between a constructor without parameters or destructor and '()'
+sp_return                   = force     # after 'return'
+sp_return_paren             = force     # space between 'return' and '('
+sp_return_brace             = force     # between 'return' and '{'
+sp_defined_paren            = force     # between 'defined' and '(' in '#if defined (FOO)'
+sp_throw_paren              = force     # between 'throw' and '(' in 'throw (something)'
+sp_catch_paren              = ignore    # between 'catch' and '(' in 'catch (something) { }'
+sp_this_paren               = remove    # between 'this' and '(' in 'this (something)'
+sp_macro                    = ignore    # between a macro name and its definition
+sp_macro_func               = ignore    # between a macro function ')' and its definition
+sp_else_brace               = force     # between 'else' and '{' if on the same line
+sp_brace_else               = force     # between '}' and 'else' if on the same line
+sp_catch_brace              = force     # before the '{' of a 'catch' statement, if the '{' and 'catch' are on the same line, as in 'catch (decl) <here> {'
+sp_brace_catch              = force     # between '}' and 'catch' if on the same line
+sp_finally_brace            = force     # between 'finally' and '{' if on the same line
+sp_brace_finally            = force     # between '}' and 'finally' if on the same line
+sp_try_brace                = force     # between 'try' and '{' if on the same line
+sp_getset_brace             = force     # between get/set and '{' if on the same line
+sp_word_brace_ns            = force     # between a variable and '{' for a namespace
+sp_not                      = remove    # after the '!' (not) unary operator
+sp_not_not                  = remove    # between two '!' (not) unary operators
+sp_inv                      = remove    # after the '~' (invert) unary operator
+sp_addr                     = remove    # after the '&' (address-of) unary operator. This does not affect the spacing after a '&' that is part of a type
+sp_member                   = remove    # around the '.' or '->' operators. also the c-sharp null-conditional operator '?.
+sp_deref                    = remove    # after the '*' (dereference) unary operator. This does not affect the spacing after a '*' that is part of a type
+sp_sign                     = remove    # after '+' or '-', as in 'x = -5' or 'y = +7'
+sp_incdec                   = remove    # between '++' and '--' the word to which it is being applied, as in '(--x)' or 'y++;'
+sp_cond_colon               = force     # around the ':' in 'b ? t : f'
+sp_cond_question            = force     # around the '?' in 'b ? t : f'
+sp_case_label               = force     # between 'case' and the label. Only 'ignore' and 'force' make sense here
+sp_after_for_colon          = force     # after ':' in a Java/C++11 range-based 'for', as in 'for (Type var : <here> expr)'
+sp_before_for_colon         = force     # before ':' in a Java/C++11 range-based 'for', as in 'for (Type var <here> : expr)'.
+sp_cmt_cpp_start            = force     # after the opening of a C++ comment, as in '// <here> A'
+sp_endif_cmt                = ignore    # between #else or #endif and a trailing comment
+sp_after_new                = force     # after 'new', 'delete' and 'delete[]'
+sp_before_tr_cmt            = force     # space before a trailing comment
+sp_num_before_tr_cmt        = 0         # Number of spaces before a trailing comment.
+sp_before_emb_cmt           = force     # before an embedded comment
+sp_num_before_emb_cmt       = 1         # Number of spaces before an embedded comment
+sp_after_emb_cmt            = force     # after an embedded comment
+sp_num_after_emb_cmt        = 1         # Number of spaces after an embedded comment
+sp_emb_cmt_priority         = true      # Embedded comment spacing options have higher priority (== override) than other spacing options (comma, parenthesis, braces, ...)
+sp_skip_vbrace_tokens       = true      #  If true, vbrace tokens are dropped to the previous token and skipped
+sp_vala_after_translation   = remove    # space after '_'
+sp_string_string            = force     # space between two strings
 
-# Comments
-cmt_star_cont			= TRUE
 
+# Indent
+indent_columns                  = 4         # The number of columns to indent per level
+indent_continue                 = 4         # The continuation indent. If non-zero, this overrides the indent of '(', '[' and '=' continuation indents. Negative values are OK; negative value is absolute and not increased for each '(' or '[' level. Requires indent_ignore_first_continue=false.
+indent_param                    = 0         # The continuation indent for func_*_param if they are true. If non-zero, this overrides the indent.
+indent_with_tabs                = 0         # How to use tabs when indenting code. 0: Spaces only 1: Indent with tabs to brace level, align with spaces (default) 2: Indent and align with tabs, using spaces when not on a tabstop
+indent_brace                    = 0         # Spaces to indent '{' from level.
+indent_braces                   = false     # Whether braces are indented to the body level.
+indent_paren_open_brace         = true      # Whether to indent based on the open parenthesis instead of the open brace in '({\n'.
+indent_namespace                = true      # Whether to indent the body of a 'namespace'.
+indent_class                    = true      # Whether the 'class' body is indented.
+indent_switch_case              = 4         # Spaces to indent 'case' from 'switch'.
+indent_switch_body              = 4         # Spaces to indent the body of a 'switch' before any 'case'.
+indent_comment                  = true      # Whether to indent comments not found in first column.
+indent_col1_comment             = true      # Whether to indent comments found in first column.
+indent_paren_close              = 2         # How to indent a close parenthesis after a newline. 0: Indent to body level (default) 1: Align under the open parenthesis 2: Indent to the brace level
+indent_comma_brace              = 0         # How to indent a comma when inside braces. 0: Indent by one level (default) 1: Align under the open brace
+indent_comma_paren              = 0         # How to indent a comma when inside parentheses. 0: Indent by one level (default) 1: Align under the open parenthesis
+indent_bool_paren               = 0         # How to indent a Boolean operator when inside parentheses. 0: Indent by one level (default) 1: Align under the open parenthesis
+indent_ternary_operator         = 2         # How to indent the continuation of ternary operator. 0: Off (default) 1: When the `if_false` is a continuation, indent it under the `if_true` branch 2: When the `:` is a continuation, indent it under `?`
+indent_inside_ternary_operator  = true      # Whether to indent the statements inside ternary operator.
+indent_single_after_return      = true      # If true, the tokens after return are indented with regular single indentation. By default (false) the indentation is after the return token.
+
+# Newline
+nl_collapse_empty_body                  = true      # Whether to collapse empty blocks between '{' and '}' except for functions.
+nl_collapse_empty_body_functions        = true      # Whether to collapse empty blocks between '{' and '}' for functions only.
+nl_start_of_file                        = remove    # at the start of the file
+nl_end_of_file                          = force     # at the end of the file
+nl_if_brace                             = remove    # between 'if' and '{'
+nl_brace_else                           = remove    # between '}' and 'else'
+nl_elseif_brace                         = remove    # between 'else if' and '{'
+nl_else_brace                           = remove    # between 'else' and '{'
+nl_else_if                              = remove    # between 'else' and 'if'
+nl_before_opening_brace_func_class_def  = remove    # before '{' opening brace
+nl_before_if_closing_paren              = ignore    # before 'if'/'else if' closing parenthesis
+nl_brace_finally                        = remove    # between '}' and 'finally'
+nl_finally_brace                        = remove    # between 'finally' and '{'
+nl_try_brace                            = remove    # between 'try' and '{'
+nl_getset_brace                         = ignore    # between get/set and '{'
+nl_for_brace                            = remove    # between 'for' and '{'
+nl_catch_brace                          = remove    # before the '{' of a 'catch' statement
+nl_brace_catch                          = remove    # between '}' and 'catch'
+nl_brace_square                         = ignore    # between '}' and ']'
+nl_brace_fparen                         = remove    # between '}' and ')' in a function invocation
+nl_while_brace                          = remove    # between 'while' and '{'
+nl_brace_brace                          = remove    # between two open or close braces. Due to general newline/brace handling, REMOVE may not work
+nl_do_brace                             = remove    # between 'do' and '{'
+nl_brace_while                          = remove    # between '}' and 'while' of 'do' statement
+nl_switch_brace                         = remove    # between 'switch' and '{'
+nl_multi_line_sparen_open               = force     # after '(' if an if/for/while/switch condition spans multiple lines
+nl_multi_line_sparen_close              = force     # before ')' if an if/for/while/switch condition spans multiple lines. Overrides nl_before_if_closing_paren if both are specified
+nl_case_colon_brace                     = remove    # between a case ':' and '{'
+nl_before_throw                         = ignore    # between ')' and 'throw'
+nl_namespace_brace                      = remove    # between 'namespace' and '{'
+nl_class_brace                          = remove    # between 'class' and '{'
+nl_class_init_args                      = remove    # before or after (depending on pos_class_comma, may not be IGNORE) each',' in the base class list
+nl_enum_own_lines                       = ignore    # before first element, after comma, and after last element, in 'enum'
+nl_func_type_name                       = remove    # between return type and function name in a function definition. might be modified by nl_func_leave_one_liners
+nl_func_proto_type_name                 = remove    # between return type and function name in a prototype
+nl_func_paren                           = remove    # between a function name and the opening '(' in the declaration
+nl_func_def_paren                       = remove    # between a function name and the opening '(' in the definition
+nl_func_call_paren                      = remove    # between a function name and the opening '(' in the call
+nl_func_decl_start                      = remove    # after '(' in a function declaration
+nl_func_def_start                       = remove    # after '(' in a function definition
+nl_func_decl_start_multi_line           = true      # Whether to add a newline after '(' in a function declaration if '(' and ')' are in different lines. If false, nl_func_decl_start is used instead.
+nl_func_def_start_multi_line            = true      # Whether to add a newline after '(' in a function definition if '(' and ')' are in different lines. If false, nl_func_def_start is used instead.
+nl_func_decl_args                       = ignore    # after each ',' in a function declaration
+nl_func_def_args                        = ignore    # after each ',' in a function definition
+nl_func_call_args                       = ignore    # after each ',' in a function call
+nl_func_decl_args_multi_line            = true      # after each ',' in a function declaration if '(' and ')' are in different lines. If false, nl_func_decl_args is used instead
+nl_func_def_args_multi_line             = false     # after each ',' in a function definition if '(' and ')' are in different lines. If false, nl_func_def_args is used instead
+nl_func_decl_end                        = ignore    # before the ')' in a function declaration
+nl_func_def_end                         = ignore    # before the ')' in a function definition
+nl_func_decl_empty                      = remove    # between '()' in a function declaration
+nl_func_def_empty                       = remove    # between '()' in a function definition
+nl_func_call_empty                      = remove    # between '()' in a function call
+nl_func_call_start                      = ignore    # after '(' in a function call, has preference over nl_func_call_start_multi_line
+nl_func_call_end                        = ignore    # before ')' in a function call
+nl_func_call_start_multi_line           = false     # after '(' in a function call if '(' and ')' are in different lines
+nl_func_call_args_multi_line            = false     # after each ',' in a function call if '(' and ')' are in different lines
+nl_func_call_end_multi_line             = false     # before ')' in a function call if '(' and ')' are in different lines
+nl_fdef_brace                           = remove    # between function signature and '{'
+nl_return_expr                          = remove    # between 'return' and the return expression
+nl_throw_expr                           = remove    # between 'throw' and the throw expression
+nl_after_vbrace_close                   = true      # after a virtual brace close, as in 'if (foo) a++; <here> return;'
+nl_create_if_one_liner                  = true      # remove a newline in simple unbraced if statements, turning them into one-liners, as in 'if(b)\n i++;' => 'if(b) i++;'.
+nl_create_for_one_liner                 = true      # Whether to remove a newline in simple unbraced for statements, turning them into one-liners, as in 'for (...)\n stmt;' => 'for (...) stmt;'.
+nl_create_while_one_liner               = true      # Whether to remove a newline in simple unbraced while statements, turning them into one-liners, as in 'while (expr)\n stmt;' => 'while (expr) stmt;'.
+nl_create_func_def_one_liner            = false     # Whether to collapse a function definition whose body (not counting braces) is only one line so that the entire definition (prototype, braces, body) is a single line.
+nl_create_list_one_liner                = false     # Whether to split one-line simple list definitions into three lines by adding newlines, as in 'int a[12] = { <here> 0 <here> };'.
+nl_split_if_one_liner                   = false     # Whether to split one-line simple unbraced if statements into two lines by adding a newline, as in 'if(b) <here> i++;'.
+nl_split_for_one_liner                  = false     # Whether to split one-line simple unbraced for statements into two lines by adding a newline, as in 'for (...) <here> stmt;'.
+nl_split_while_one_liner                = false     # Whether to split one-line simple unbraced while statements into two lines by adding a newline, as in 'while (expr) <here> stmt;'.
+
+# Positioning options
+pos_conditional                 = break     # The position of conditional operators, as in the '?' and ':' of 'expr ? stmt : stmt', in wrapped expressions
+
+# Blank line options
+nl_max                          = 2         # The maximum number of consecutive newlines (3 = 2 blank lines).
+nl_max_blank_in_func            = 2         # The maximum number of consecutive newlines in a function.
+eat_blanks_after_open_brace     = true      # Whether to remove blank lines after '{'.
+eat_blanks_before_close_brace   = true      # Whether to remove blank lines before '}'.
+
+# Code modifying options (non-whitespace)
+mod_full_brace_do               = force     # braces on a single-line 'do' statement
+mod_full_brace_for              = force     # braces on a single-line 'for' statement
+mod_full_brace_if               = force     # braces on a single-line 'if' statement. Braces will not be removed if the braced statement contains an 'else'
+mod_full_brace_if_chain         = 2         # enforce that all blocks of an 'if'/'else if'/'else' chain either have, or do not have, braces. Overrides mod_full_brace_if
+mod_full_brace_if_chain_only    = true      # add braces to all blocks of an 'if'/'else if'/'else' chain. If true, mod_full_brace_if_chain will only remove braces from an 'if' that does not have an 'else if' or 'else'
+mod_full_brace_while            = force     # braces on single-line 'while' statement
+mod_paren_on_return             = ignore    # unnecessary parentheses on 'return' statement
+mod_paren_on_throw              = ignore    # unnecessary parentheses on 'throw' statement
+mod_full_paren_if_bool          = true      # fully parenthesize Boolean expressions in 'while' and 'if' statement, as in 'if (a && b > c)' => 'if (a && (b > c))'
+mod_full_paren_assign_bool      = true      # fully parenthesize Boolean expressions after '=' statement, as in 'x = a && b > c;' => 'x = (a && (b > c));'
+mod_full_paren_return_bool      = false     # fully parenthesize Boolean expressions after '=' statement, as in 'return  a && b > c;' => 'return (a && (b > c));'
+mod_remove_extra_semicolon      = true      # remove superfluous semicolons
+mod_move_case_break             = true      # move a 'break' that appears after a fully braced 'case' before the close brace, as in 'case X: { ... } break;' => 'case X: { ... break; }'
+mod_move_case_return            = true      # move a 'return' that appears after a fully braced 'case' before the close brace, as in 'case X: { ... } return;' => 'case X: { ... return; }'
+mod_case_brace                  = ignore    # remove braces around a fully braced case statement. Will only remove braces if there are no variable declarations in the block
+mod_remove_empty_return         = false     # remove a void 'return;' that appears as the last statement in a function
+mod_enum_last_comma             = ignore    # remove the comma after the last value of an enumeration

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -8,9 +8,10 @@ indent_with_tabs		= 0		# 1=indent to level only, 2=indent with tabs
 indent_columns			= output_tab_size
 indent_align_string		= False		# align broken strings
 indent_brace			= 0
-indent_class			= FALSE
+indent_class			= TRUE
 indent_namespace		= FALSE
 indent_member           = 0
+indent_paren_open_brace         = TRUE    # true/false
 # How to indent a close parenthesis after a newline.
 #
 #  0: Indent to body level (default)

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -1,8 +1,8 @@
-newlines                        = LF		# AUTO (default), CRLF, CR, or LF
+newlines                = auto
+input_tab_size          = 8
+output_tab_size         = 8
 
 indent_with_tabs		= 2		# 1=indent to level only, 2=indent with tabs
-input_tab_size			= 8		# original tab size
-output_tab_size			= 3		# new tab size
 indent_columns			= output_tab_size
 indent_align_string		= False		# align broken strings
 indent_brace			= 0
@@ -82,25 +82,5 @@ sp_fparen_brace			= add
 sp_after_ptr_star		= remove
 sp_before_ptr_star		= force
 sp_between_ptr_star		= remove
-
-# align_with_tabs			= TRUE		# use tabs to align
-# align_on_tabstop		= FALSE		# align on tabstops
-# align_enum_equ_span		= 4
-# align_nl_cont			= 1
-# align_var_def_span		= 1
-# align_var_def_thresh	= 12
-# align_var_def_inline	= FALSE
-# align_var_def_colon		= FALSE
-# align_assign_span		= 1
-# align_assign_thresh		= 12
-# align_struct_init_span		= 3
-# align_var_struct_span		= 99
-# align_right_cmt_span		= 3
-# align_pp_define_span		= 3
-# align_pp_define_gap		= 4
-# align_number_right		= TRUE
-# align_typedef_span		= 5
-# align_typedef_gap		= 3
-
 cmt_star_cont			= TRUE
 

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -39,6 +39,8 @@ nl_while_brace			    = remove		# "while () {" vs "while () \n {"
 nl_switch_brace			    = remove		# "switch () {" vs "switch () \n {"
 nl_var_def_blk_end_func_top	= 1
 nl_before_case			    = 1
+nl_namespace_brace          = remove
+nl_class_brace              = remove
 nl_fcall_brace			    = remove		# "foo() {" vs "foo()\n{"
 nl_fdef_brace			    = remove		# "int foo() {" vs "int foo()\n{"
 nl_after_return			    = TRUE
@@ -50,7 +52,6 @@ nl_squeeze_ifdef		    = TRUE
 pos_bool			            = trail		# BOOL ops on trailing end
 # The position of conditional operators, as in the '?' and ':' of
 # 'expr ? stmt : stmt', in wrapped expressions.
-# ARKye03 msg, please don't use trail, it's awful
 pos_conditional                 = break   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
 
 # Eat blanks

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -17,6 +17,11 @@ indent_member           = 0
 # -1: Preserve original indentation
 indent_paren_close      = 2
 
+# The position of conditional operators, as in the '?' and ':' of
+# 'expr ? stmt : stmt', in wrapped expressions.
+# ARKye03 msg, please don't use trail, it's awful
+pos_conditional                 = break   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
+
 nl_start_of_file		= remove
 nl_end_of_file			= force
 nl_end_of_file_min		= 1

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -8,6 +8,8 @@ indent_align_string		= False		# align broken strings
 indent_brace			= 0
 indent_class			= FALSE
 indent_namespace		= FALSE
+indent_paren_close      = 0
+indent_paren_after_func_def = FALSE
 
 nl_start_of_file		= remove
 nl_end_of_file			= force

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -8,7 +8,7 @@ indent_align_string		= False		# align broken strings
 indent_brace			= 0
 indent_class			= FALSE
 indent_namespace		= FALSE
-
+indent_member           = 0
 # How to indent a close parenthesis after a newline.
 #
 #  0: Indent to body level (default)

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -1,12 +1,12 @@
 newlines                = auto
 input_tab_size          = 8
-output_tab_size         = 8
+output_tab_size         = 4
 
 indent_with_tabs		= 0		# 1=indent to level only, 2=indent with tabs
 indent_columns			= output_tab_size
 indent_align_string		= False		# align broken strings
 indent_brace			= 0
-indent_class			= true
+indent_class			= FALSE
 indent_namespace		= FALSE
 
 nl_start_of_file		= remove


### PR DESCRIPTION
>[!WARNING]
> There is a bug with uncrustify in `lib/apps/application.vala` line *59* (after formatting), that deletes the `;`, adding it back after formatting the file will work as expected and no more issues should arise.

Add [uncrustify](https://github.com/uncrustify/uncrustify) for consistent formatting rules across `Vala` and `C` files. Vala example result:
`lib/apps/fuzzy.vala`
<details> 
<summary>from</summary>

```csharp
namespace AstalApps {
private int fuzzy_match_string(string pattern, string str) {
    const int unmatched_letter_penalty = -1;
    int score = 100;

    if (pattern.length == 0) return score;
    if (str.length < pattern.length) return int.MIN;

    bool found = fuzzy_match_recurse(pattern, str, score, true, out score);
    score += unmatched_letter_penalty * (str.length - pattern.length);
    
    if(!found) score = -10;

    return score;
}

private bool fuzzy_match_recurse(string pattern, string str, int score, bool first_char, out int result) {
    result = score;
    if (pattern.length == 0) return true;

    int match_idx = 0;
    int offset = 0;
    unichar search = pattern.casefold().get_char(0);
    int best_score = int.MIN;

    while ((match_idx = str.casefold().substring(offset).index_of_char(search)) >= 0) {
        offset += match_idx;
        int subscore;
        bool found = fuzzy_match_recurse(
            pattern.substring(1),
            str.substring(offset + 1),
            compute_score(offset, first_char, str, offset), false, out subscore);
        if(!found) break;
        best_score = int.max(best_score, subscore);
        offset++;
    }
    
    if (best_score == int.MIN) return false;
    result += best_score;
    return true;
}

private int compute_score(int jump, bool first_char, string match, int idx) {
    const int adjacency_bonus = 15;
    const int separator_bonus = 30;
    const int camel_bonus = 30;
    const int first_letter_bonus = 15;
    const int leading_letter_penalty = -5;
    const int max_leading_letter_penalty = -15;

    int score = 0;

    if (!first_char && jump == 0) {
        score += adjacency_bonus;
    }
    if (!first_char || jump > 0) {
        if (match[idx].isupper() && match[idx-1].islower()) {
            score += camel_bonus;
        }
        if (match[idx].isalnum() && !match[idx-1].isalnum()) {
            score += separator_bonus;
        }
    }
    if (first_char && jump == 0) {
        score += first_letter_bonus;
    }
    if (first_char) {
        score += int.max(leading_letter_penalty * jump, max_leading_letter_penalty);
    }

    return score;
}
}
```
</details>
<details> 
<summary>to</summary>

```csharp
namespace AstalApps {
private int fuzzy_match_string(string pattern, string str) {
	const int unmatched_letter_penalty = -1;
	int score = 100;

	if (pattern.length == 0) {
		return score;
	}
	if (str.length < pattern.length) {
		return int.MIN;
	}

	bool found = fuzzy_match_recurse(pattern, str, score, true, out score);
	score += unmatched_letter_penalty * (str.length - pattern.length);

	if (!found) {
		score = -10;
	}

	return score;
}

private bool fuzzy_match_recurse(string pattern, string str, int score, bool first_char, out int result) {
	result = score;
	if (pattern.length == 0) {
		return true;
	}

	int match_idx = 0;
	int offset = 0;
	unichar search = pattern.casefold().get_char(0);
	int best_score = int.MIN;

	while ((match_idx = str.casefold().substring(offset).index_of_char(search)) >= 0) {
		offset += match_idx;
		int subscore;
		bool found = fuzzy_match_recurse(
			pattern.substring(1),
			str.substring(offset + 1),
			compute_score(offset, first_char, str, offset), false, out subscore);
		if (!found) {
			break;
		}
		best_score = int.max(best_score, subscore);
		offset++;
	}

	if (best_score == int.MIN) {
		return false;
	}
	result += best_score;
	return true;
}

private int compute_score(int jump, bool first_char, string match, int idx) {
	const int adjacency_bonus = 15;
	const int separator_bonus = 30;
	const int camel_bonus = 30;
	const int first_letter_bonus = 15;
	const int leading_letter_penalty = -5;
	const int max_leading_letter_penalty = -15;

	int score = 0;

	if (!first_char && jump == 0) {
		score += adjacency_bonus;
	}
	if (!first_char || jump > 0) {
		if (match[idx].isupper() && match[idx - 1].islower()) {
			score += camel_bonus;
		}
		if (match[idx].isalnum() && !match[idx - 1].isalnum()) {
			score += separator_bonus;
		}
	}
	if (first_char && jump == 0) {
		score += first_letter_bonus;
	}
	if (first_char) {
		score += int.max(leading_letter_penalty * jump, max_leading_letter_penalty);
	}

	return score;
}
}
```
</details>

### Summary
- Indentation based on tabs
- Unindented namespaces
- No space before parens on function declarations
- Keywords like `if`, `else`, `catch`, etc will have space before parens. 

### A full showcase of all formatted files can be seen at <https://github.com/ARKye03/astal/tree/refactor-style>

>[!NOTE]
> I ran `fd -e c -e h -e vala . | xargs uncrustify -c uncrustify.cfg --no-backup`  for it