### PR TITLE
example: fix sass deprecation warnings

### DIFF
--- a/examples/js/simple-bar/style.scss
+++ b/examples/js/simple-bar/style.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $bg: #212223;
 $fg: #f1f1f1;
 $accent: #378DF7;
@@ -16,12 +18,12 @@ window.Bar {
         background-color: transparent;
 
         &:hover label {
-            background-color: transparentize($fg, 0.84);
-            border-color: transparentize($accent, 0.8);
+            background-color: color.adjust($fg, $alpha: -0.84);
+            border-color: color.adjust($accent, $alpha: -0.8);
         }
 
         &:active label {
-            background-color: transparentize($fg, 0.8)
+            background-color: color.adjust($fg, $alpha: -0.8)
         }
     }
 
@@ -64,10 +66,12 @@ window.Bar {
             margin-right: .6em;
         }
 
-        margin: 0 1em;
+        & {
+            margin: 0 1em;
+        }
 
         trough {
-            background-color: transparentize($fg, 0.8);
+            background-color: color.adjust($fg, $alpha: -0.8);
             border-radius: $radius;
         }
 

--- a/examples/lua/simple-bar/style.scss
+++ b/examples/lua/simple-bar/style.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $bg: #212223;
 $fg: #f1f1f1;
 $accent: #378DF7;
@@ -16,12 +18,12 @@ window.Bar {
         background-color: transparent;
 
         &:hover label {
-            background-color: transparentize($fg, 0.84);
-            border-color: transparentize($accent, 0.8);
+            background-color: color.adjust($fg, $alpha: -0.84);
+            border-color: color.adjust($accent, $alpha: -0.8);
         }
 
         &:active label {
-            background-color: transparentize($fg, 0.8)
+            background-color: color.adjust($fg, $alpha: -0.8)
         }
     }
 
@@ -64,10 +66,12 @@ window.Bar {
             margin-right: .6em;
         }
 
-        margin: 0 1em;
+        & {
+            margin: 0 1em;
+        }
 
         trough {
-            background-color: transparentize($fg, 0.8);
+            background-color: color.adjust($fg, $alpha: -0.8);
             border-radius: $radius;
         }
 

--- a/examples/py/simple-bar/style.scss
+++ b/examples/py/simple-bar/style.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $bg: #212223;
 $fg: #f1f1f1;
 $accent: #378DF7;
@@ -16,12 +18,12 @@ window.Bar {
         background-color: transparent;
 
         &:hover label {
-            background-color: transparentize($fg, 0.84);
-            border-color: transparentize($accent, 0.8);
+            background-color: color.adjust($fg, $alpha: -0.84);
+            border-color: color.adjust($accent, $alpha: -0.8);
         }
 
         &:active label {
-            background-color: transparentize($fg, 0.8)
+            background-color: color.adjust($fg, $alpha: -0.8)
         }
     }
 
@@ -64,10 +66,12 @@ window.Bar {
             margin-right: .6em;
         }
 
-        margin: 0 1em;
+        & {
+            margin: 0 1em;
+        }
 
         trough {
-            background-color: transparentize($fg, 0.8);
+            background-color: color.adjust($fg, $alpha: -0.8);
             border-radius: $radius;
         }
 

--- a/examples/vala/simple-bar/style.scss
+++ b/examples/vala/simple-bar/style.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $bg: #212223;
 $fg: #f1f1f1;
 $accent: #378DF7;
@@ -16,12 +18,12 @@ window.Bar {
         background-color: transparent;
 
         &:hover label {
-            background-color: transparentize($fg, 0.84);
-            border-color: transparentize($accent, 0.8);
+            background-color: color.adjust($fg, $alpha: -0.84);
+            border-color: color.adjust($accent, $alpha: -0.8);
         }
 
         &:active label {
-            background-color: transparentize($fg, 0.8)
+            background-color: color.adjust($fg, $alpha: -0.8)
         }
     }
 
@@ -64,10 +66,12 @@ window.Bar {
             margin-right: .6em;
         }
 
-        margin: 0 1em;
+        & {
+            margin: 0 1em;
+        }
 
         trough {
-            background-color: transparentize($fg, 0.8);
+            background-color: color.adjust($fg, $alpha: -0.8);
             border-radius: $radius;
         }
 


### PR DESCRIPTION
Fix the following warnings,

```
DEPRECATION WARNING: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
Use color.adjust instead.

More info and automated migrator: https://sass-lang.com/d/import

   ╷
19 │             background-color: transparentize($fg, 0.84);
   │                               ^^^^^^^^^^^^^^^^^^^^^^^^^
```

```
DEPRECATION WARNING: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

    ╷
59  │ ┌         * {
60  │ │             all: unset;
61  │ │         }
    │ └─── nested rule
... │
67  │           margin: 0 1em;
    │           ^^^^^^^^^^^^^ declaration
```