### PR TITLE
docs: fix  first-widgets.md

### DIFF
--- a/docs/guide/typescript/first-widgets.md
+++ b/docs/guide/typescript/first-widgets.md
@@ -275,7 +275,7 @@ function Counter() {
         <label label={bind(count).as(num => num.toString())} />
         <button onClicked={increment}>
             Click to increment
-        <button>
+        </button>
     </box>
 }
 ```


### PR DESCRIPTION
The <button> tag in the code is missing a /`