### PR TITLE
mpris: fix typo in dbus property

### DIFF
--- a/lib/mpris/cli.vala
+++ b/lib/mpris/cli.vala
@@ -179,7 +179,7 @@ int main(string[] argv) {
 
 Json.Node to_json(Player p) {
     var uris = new Json.Builder().begin_array();
-    foreach (var uri in p.supported_uri_schemas)
+    foreach (var uri in p.supported_uri_schemes)
         uris.add_string_value(uri);
 
     uris.end_array();
@@ -189,7 +189,7 @@ Json.Node to_json(Player p) {
         .set_member_name("available").add_boolean_value(p.available)
         .set_member_name("identity").add_string_value(p.identity)
         .set_member_name("entry").add_string_value(p.entry)
-        .set_member_name("supported_uri_schemas").add_value(uris.get_root())
+        .set_member_name("supported_uri_schemes").add_value(uris.get_root())
         .set_member_name("loop_status").add_string_value(p.loop_status.to_string())
         .set_member_name("shuffle_status").add_string_value(p.shuffle_status.to_string())
         .set_member_name("rate").add_double_value(p.rate)

--- a/lib/mpris/ifaces.vala
+++ b/lib/mpris/ifaces.vala
@@ -21,7 +21,7 @@ private interface AstalMpris.IMpris : PropsIface {
     public abstract bool has_track_list { get; }
     public abstract string identity { owned get; }
     public abstract string desktop_entry { owned get; }
-    public abstract string[] supported_uri_schemas { owned get; }
+    public abstract string[] supported_uri_schemes { owned get; }
     public abstract string[] supported_mime_types { owned get; }
 }
 

--- a/lib/mpris/player.vala
+++ b/lib/mpris/player.vala
@@ -87,7 +87,7 @@ public class AstalMpris.Player : Object {
      * Almost every media player will include support for the "file" scheme.
      * Other common schemes are "http" and "rtsp".
      */
-    public string[] supported_uri_schemas { owned get; private set; }
+    public string[] supported_uri_schemes { owned get; private set; }
 
     /**
      * The mime-types supported by the player.
@@ -160,7 +160,7 @@ public class AstalMpris.Player : Object {
     }
 
     /**
-     * uri scheme should be an element of [property@AstalMpris.Player:supported_uri_schemas]
+     * uri scheme should be an element of [property@AstalMpris.Player:supported_uri_schemes]
      * and the mime-type should match one of the elements of [property@AstalMpris.Player:supported_mime_types].
      *
      * @param uri Uri of the track to load.
@@ -425,7 +425,7 @@ public class AstalMpris.Player : Object {
         // has_track_list = proxy.has_track_list;
         identity = proxy.identity;
         entry = proxy.desktop_entry;
-        supported_uri_schemas = proxy.supported_uri_schemas;
+        supported_uri_schemes = proxy.supported_uri_schemes;
         supported_mime_types = proxy.supported_mime_types;
 
         if (position >= 0)


### PR DESCRIPTION
the property is called SupportedUriSchemes not SupportedUriSchemas

https://specifications.freedesktop.org/mpris-spec/latest/Media_Player.html#Property:SupportedUriSchemes