### PR TITLE
add --force arg to valadoc

### DIFF
--- a/lib/gir.py
+++ b/lib/gir.py
@@ -48,7 +48,17 @@ def fix_gir(name: str, gir: str, out: str):
 
 
 def valadoc(name: str, gir: str, args: list[str]):
-    cmd = [os.getenv("VALADOC", "valadoc"), "-o", "docs", "--package-name", name, "--gir", gir, *args]
+    cmd = [
+        os.getenv("VALADOC", "valadoc"),
+        "--force",
+        "-o",
+        "docs",
+        "--package-name",
+        name,
+        "--gir",
+        gir,
+        *args,
+    ]
     try:
         subprocess.run(cmd, check=True, text=True, capture_output=True)
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
Hi!

I occasionally want to pull repo changes and update some lib with 
```
meson setup --prefix /usr build
meson install -C build
```
but I get `valadoc` error on a second command: `File already exists`. One option is to nuke `build/docs` dir each time, other is to force the generation. wdyt?