### PR TITLE
set mergeBindings to minimum of 2 values and fix return type issue. 

### DIFF
--- a/lang/gjs/src/gtk3/astalify.ts
+++ b/lang/gjs/src/gtk3/astalify.ts
@@ -6,7 +6,8 @@ import { execAsync } from "../process.js"
 import Variable from "../variable.js"
 import Binding, { kebabify, snakeify, type Connectable, type Subscribable } from "../binding.js"
 
-export function mergeBindings(array: any[]) {
+export function mergeBindings(array: [Binding<any>, Binding<any>, ...Binding<any>[]]) : Binding<any[]> {
+
     function getValues(...args: any[]) {
         let i = 0
         return array.map(value => value instanceof Binding
@@ -14,16 +15,8 @@ export function mergeBindings(array: any[]) {
             : value,
         )
     }
-
-    const bindings = array.filter(i => i instanceof Binding)
-
-    if (bindings.length === 0)
-        return array
-
-    if (bindings.length === 1)
-        return bindings[0].as(getValues)
-
-    return Variable.derive(bindings, getValues)()
+    
+    return Variable.derive(array, getValues)()
 }
 
 function setProp(obj: any, prop: string, value: any) {


### PR DESCRIPTION
Currently if you merge any number of bindings there is a type problem where the return type can be any[] which in turn means that you can't do .as() on the return values without the hint suggestion giving a warning.

The current mergeBindings function accepts any number of elements in an array with type any as argument. In my implementation the type is restricted to bindings and has a minimum of 2 bindings that must be provided. This allows removal of filtering and cases where the length of the array is 0 or 1 since it becomes unnecessary. Also the return type is explicitly declared since the return type in the previous implementation can return a any[] (although this is unnecessary).