### PR TITLE
feat: add battery_percentage to bluetooth devices

### DIFF
--- a/lib/bluetooth/battery.vala
+++ b/lib/bluetooth/battery.vala
@@ -1,0 +1,33 @@
+/**
+ * Object representing a [[https://github.com/bluez/bluez/blob/master/doc/org.bluez.Battery.rst|battery]].
+ */
+public class AstalBluetooth.Battery : Object {
+    private IBattery proxy;
+
+    internal ObjectPath object_path { owned get; private set; }
+
+    internal Battery(IBattery proxy) {
+        this.proxy = proxy;
+        this.object_path = (ObjectPath)proxy.g_object_path;
+        proxy.g_properties_changed.connect((props) => {
+            var map = (HashTable<string, Variant>)props;
+            foreach (var key in map.get_keys()) {
+                var prop = kebab_case(key);
+                if (get_class().find_property(prop) != null) {
+                    notify_property(prop);
+                }
+            }
+        });
+    }
+
+    /**
+     * The percentage of battery left as an unsigned 8-bit integer.
+     */
+    public uint percentage { get { return proxy.percentage; } }
+
+    /**
+     * Describes where the battery information comes from. 
+     */
+    public string source { owned get { return proxy.source; } }
+
+}

--- a/lib/bluetooth/battery.vala
+++ b/lib/bluetooth/battery.vala
@@ -1,7 +1,7 @@
 /**
  * Object representing a [[https://github.com/bluez/bluez/blob/master/doc/org.bluez.Battery.rst|battery]].
  */
-public class AstalBluetooth.Battery : Object {
+internal class AstalBluetooth.Battery : Object {
     private IBattery proxy;
 
     internal ObjectPath object_path { owned get; private set; }

--- a/lib/bluetooth/bluetooth.vala
+++ b/lib/bluetooth/bluetooth.vala
@@ -170,7 +170,7 @@ public class AstalBluetooth.Bluetooth : Object {
             var battery = new Battery((IBattery)iface);
             var device = _devices.lookup(iface.g_object_path);
             if (device != null) {
-                device.battery = battery;
+                device.set_battery(battery);
             } 
             sync();
         }

--- a/lib/bluetooth/bluetooth.vala
+++ b/lib/bluetooth/bluetooth.vala
@@ -138,6 +138,9 @@ public class AstalBluetooth.Bluetooth : Object {
     [CCode (cname="astal_bluetooth_iadapter_proxy_get_type")]
     extern static GLib.Type get_iadapter_proxy_type();
 
+    [CCode (cname="astal_bluetooth_ibattery_proxy_get_type")]
+    extern static GLib.Type get_ibattery_proxy_type();
+
     private Type manager_proxy_get_type(DBusObjectManagerClient _, string object_path, string? interface_name) {
         if (interface_name == null)
             return typeof(DBusObjectProxy);
@@ -147,6 +150,8 @@ public class AstalBluetooth.Bluetooth : Object {
                 return get_idevice_proxy_type();
             case "org.bluez.Adapter1":
                 return get_iadapter_proxy_type();
+            case "org.bluez.Battery1":
+                return get_ibattery_proxy_type();
             default:
                 return typeof(DBusProxy);
         }
@@ -158,6 +163,15 @@ public class AstalBluetooth.Bluetooth : Object {
             _devices.set(device.object_path, device);
             device_added(device);
             device.notify.connect(sync);
+            sync();
+        }
+
+        if (iface is IBattery) {
+            var battery = new Battery((IBattery)iface);
+            var device = _devices.lookup(iface.g_object_path);
+            if (device != null) {
+                device.battery = battery;
+            } 
             sync();
         }
 

--- a/lib/bluetooth/device.vala
+++ b/lib/bluetooth/device.vala
@@ -114,12 +114,12 @@ public class AstalBluetooth.Device : Object {
     }
 
     /**
-     * The percentage of battery left on the device if it has one, else 0.
+     * The percentage of battery left on the device if it has one, else -1.
      */
-    public uint battery_percentage { 
+    public double battery_percentage { 
         get { 
-            if (battery != null) return battery.percentage;
-            else return 0;
+            if (battery != null) return battery.percentage * 0.01;
+            else return -1;
         } 
     }
 

--- a/lib/bluetooth/device.vala
+++ b/lib/bluetooth/device.vala
@@ -3,7 +3,7 @@
  */
 public class AstalBluetooth.Device : Object {
     private IDevice proxy;
-    public Battery battery;
+    private Battery battery;
 
     internal ObjectPath object_path { owned get; private set; }
 
@@ -18,6 +18,15 @@ public class AstalBluetooth.Device : Object {
                     notify_property(prop);
                 }
             }
+        });
+    }
+
+    internal void set_battery(Battery battery) {
+        this.battery = battery;
+
+        notify_property("battery_percentage");
+        battery.notify["percentage"].connect((obj, pspec) => {
+            notify_property("battery_percentage");
         });
     }
 
@@ -105,10 +114,14 @@ public class AstalBluetooth.Device : Object {
     }
 
     /**
-     * The percentage of battery left as an unsigned 8-bit integer.
+     * The percentage of battery left on the device if it has one, else 0.
      */
-    public uint battery_percentage { get { return battery.percentage; } }
-
+    public uint battery_percentage { 
+        get { 
+            if (battery != null) return battery.percentage;
+            else return 0;
+        } 
+    }
 
     /**
      * The name alias for the remote device.
@@ -143,6 +156,7 @@ public class AstalBluetooth.Device : Object {
     public async void disconnect_device() throws Error {
         yield proxy.disconnect();
     }
+
 
     /**
      * This method connects a specific profile of this device.

--- a/lib/bluetooth/device.vala
+++ b/lib/bluetooth/device.vala
@@ -3,6 +3,7 @@
  */
 public class AstalBluetooth.Device : Object {
     private IDevice proxy;
+    public Battery battery;
 
     internal ObjectPath object_path { owned get; private set; }
 
@@ -102,6 +103,12 @@ public class AstalBluetooth.Device : Object {
         get { return proxy.trusted; }
         set { proxy.trusted = value; }
     }
+
+    /**
+     * The percentage of battery left as an unsigned 8-bit integer.
+     */
+    public uint battery_percentage { get { return battery.percentage; } }
+
 
     /**
      * The name alias for the remote device.

--- a/lib/bluetooth/interfaces.vala
+++ b/lib/bluetooth/interfaces.vala
@@ -44,3 +44,8 @@ private interface AstalBluetooth.IDevice : DBusProxy {
     public abstract uint32 class { get; }
 }
 
+[DBus (name = "org.bluez.Battery1")]
+private interface AstalBluetooth.IBattery : DBusProxy {
+    public abstract uint8 percentage { get; }
+    public abstract string source { owned get; }
+}

--- a/lib/bluetooth/meson.build
+++ b/lib/bluetooth/meson.build
@@ -37,6 +37,7 @@ sources = [config] + files(
   'adapter.vala',
   'bluetooth.vala',
   'device.vala',
+  'battery.vala',
   'interfaces.vala',
   'utils.vala',
 )


### PR DESCRIPTION
Fixes #138 

Using the Bluez [Battery API](https://github.com/bluez/bluez/blob/master/doc/org.bluez.Battery.rst) to add battery_percentage to bluetooth devices.

Can be used through:
```typescript
let mydevice = devices.get()[0]; // or map etc.
let battery = bind(mydevice, "battery_percentage");
```