### PR TITLE
fix(network): specify values for State enum

### DIFF
--- a/lib/network/network.vala
+++ b/lib/network/network.vala
@@ -104,14 +104,14 @@ public enum AstalNetwork.Primary {
 
 // alias for NM.State
 public enum AstalNetwork.State {
-    UNKNOWN,
-    ASLEEP,
-    DISCONNECTED,
-    DISCONNECTING,
-    CONNECTING,
-    CONNECTED_LOCAL,
-    CONNECTED_SITE,
-    CONNECTED_GLOBAL;
+    UNKNOWN = 0,
+    ASLEEP = 10,
+    DISCONNECTED = 20,
+    DISCONNECTING = 30,
+    CONNECTING = 40,
+    CONNECTED_LOCAL = 50,
+    CONNECTED_SITE = 60,
+    CONNECTED_GLOBAL = 70;
 
     public string to_string() {
         switch (this) {


### PR DESCRIPTION
Specifies the values for `State` in `AstalNetwork.Network` according to the [NetworkManager D-Bus API Types](https://people.freedesktop.org/~lkundrak/nm-docs/nm-dbus-types.html).

This fixes a critical bug that would cause applications to crash because (e.g.) `70` previously was not a valid value for `State`.