### PR TITLE
Add aarch64 Compatability to Flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
   }: let
     inherit (builtins) replaceStrings readFile;
     readVer = file: replaceStrings ["\n"] [""] (readFile file);
-    supportedSystems = ["x86_64-linux"];
+    supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
     forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: (forSystem system f));
     forSystem = system: f: f rec {
       inherit system;

--- a/flake.nix
+++ b/flake.nix
@@ -5,45 +5,48 @@
   }: let
     inherit (builtins) replaceStrings readFile;
     readVer = file: replaceStrings ["\n"] [""] (readFile file);
-
-    system = "x86_64-linux"; # TODO: other architectures
-    pkgs = nixpkgs.legacyPackages.${system};
-
-    mkPkg = name: src: inputs:
-      pkgs.stdenv.mkDerivation {
-        nativeBuildInputs = with pkgs; [
-          wrapGAppsHook
-          gobject-introspection
-          meson
-          pkg-config
-          ninja
-          vala
-          wayland
-          wayland-scanner
-          python3
-        ];
-        propagatedBuildInputs = [pkgs.glib] ++ inputs;
-        pname = name;
-        version = readVer "${src}/version";
-        src = src;
-        postUnpack = ''
-          cp --remove-destination ${./lib/gir.py} $sourceRoot/gir.py
-        '';
-        outputs = ["out" "dev"];
-      };
-  in {
-    devShells.${system} = import ./nix/devshell.nix {
-      inherit self pkgs;
+    supportedSystems = ["x86_64-linux"];
+    forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: (forSystem system f));
+    forSystem = system: f: f rec {
+      inherit system;
+      pkgs = nixpkgs.legacyPackages.${system};
+      mkPkg = name: src: inputs:
+	pkgs.stdenv.mkDerivation {
+	  nativeBuildInputs = with pkgs; [
+	    wrapGAppsHook
+	    gobject-introspection
+	    meson
+	    pkg-config
+	    ninja
+	    vala
+	    wayland
+	    wayland-scanner
+	    python3
+	  ];
+	  propagatedBuildInputs = [pkgs.glib] ++ inputs;
+	  pname = name;
+	  version = readVer "${src}/version";
+	  src = src;
+	  postUnpack = ''
+	    cp --remove-destination ${./lib/gir.py} $sourceRoot/gir.py
+	  '';
+	  outputs = ["out" "dev"];
+	};
     };
+  in {
 
-    lib = {
+    devShells = forAllSystems({system, pkgs, ...}: import ./nix/devshell.nix {
+        inherit self pkgs;
+    });
+
+    lib = forAllSystems({system, pkgs, ...}: {
       mkLuaPackage = import ./nix/lua.nix {
         inherit pkgs;
         astal = self;
       };
-    };
+    });
 
-    packages.${system} = with pkgs; {
+    packages = forAllSystems({system, pkgs, mkPkg, ...}: with pkgs;{
       docs = import ./docs {inherit self pkgs;};
       default = self.packages.${system}.io;
 
@@ -66,17 +69,17 @@
       wireplumber = mkPkg "astal-wireplumber" ./lib/wireplumber [wireplumber];
 
       gjs = pkgs.stdenvNoCC.mkDerivation {
-        src = ./lang/gjs;
-        name = "astal-gjs";
-        nativeBuildInputs = [
-          meson
-          ninja
-          pkg-config
-          self.packages.${system}.io
-          self.packages.${system}.astal3
-        ];
+	src = ./lang/gjs;
+	name = "astal-gjs";
+	nativeBuildInputs = [
+	  meson
+	  ninja
+	  pkg-config
+	  self.packages.${system}.io
+	  self.packages.${system}.astal3
+	];
       };
-    };
+    });
   };
 
   inputs = {

--- a/flake.nix
+++ b/flake.nix
@@ -69,15 +69,15 @@
       wireplumber = mkPkg "astal-wireplumber" ./lib/wireplumber [wireplumber];
 
       gjs = pkgs.stdenvNoCC.mkDerivation {
-	src = ./lang/gjs;
-	name = "astal-gjs";
-	nativeBuildInputs = [
-	  meson
-	  ninja
-	  pkg-config
-	  self.packages.${system}.io
-	  self.packages.${system}.astal3
-	];
+        src = ./lang/gjs;
+        name = "astal-gjs";
+        nativeBuildInputs = [
+          meson
+          ninja
+          pkg-config
+          self.packages.${system}.io
+          self.packages.${system}.astal3
+        ];
       };
     });
   };


### PR DESCRIPTION
Added supporting framework in flake.nix for multiple architectures, and added aarch64-linux support using that framework. Support for multiple architectures is based on system I believe originally developed by DeterminateSystems, you can view an example [here](https://github.com/DeterminateSystems/zero-to-nix/blob/main/flake.nix). Other tools are available to achieve the same, but this one required minimal changes to existing flake.

Tested that everything builds successfully 

This change means you now have to specify a dependency when using the "lib" output from the flake as that has a dependency on pkgs, which is dependent on the system.