### PR TITLE
astal3 icon: use Gtk Image's GIcon

### DIFF
--- a/examples/js/simple-bar/widget/Bar.tsx
+++ b/examples/js/simple-bar/widget/Bar.tsx
@@ -18,9 +18,9 @@ function SysTray() {
                 usePopover={false}
                 actionGroup={bind(item, "action-group").as(ag => ["dbusmenu", ag])}
                 menuModel={bind(item, "menu-model")}>
-                <icon gIcon={bind(item, "gicon")} />
+                <icon gicon={bind(item, "gicon")} />
             </menubutton>
-        ))}
+        )))}
     </box>
 }
 

--- a/examples/lua/simple-bar/widget/Bar.lua
+++ b/examples/lua/simple-bar/widget/Bar.lua
@@ -26,7 +26,7 @@ local function SysTray()
 						return { "dbusmenu", ag }
 					end),
 					Widget.Icon({
-						g_icon = bind(item, "gicon"),
+						gicon = bind(item, "gicon"),
 					}),
 				})
 			end)
@@ -127,7 +127,7 @@ local function Workspaces()
 			end)
 
 			return map(wss, function(ws)
-				if !(ws.id >= -99 and ws.id <= -2) then -- filter out special workspaces
+				if not (ws.id >= -99 and ws.id <= -2) then -- filter out special workspaces
 					return Widget.Button({
 						class_name = bind(hypr, "focused-workspace"):as(function(fw)
 							return fw == ws and "focused" or ""

--- a/examples/py/simple-bar/widget/Bar.py
+++ b/examples/py/simple-bar/widget/Bar.py
@@ -124,7 +124,7 @@ class SysTray(Gtk.Box):
         icon = Astal.Icon(visible=True)
 
         item.bind_property("tooltip-markup", btn, "tooltip-markup", SYNC)
-        item.bind_property("gicon", icon, "g-icon", SYNC)
+        item.bind_property("gicon", icon, "gicon", SYNC)
         item.bind_property("menu-model", btn, "menu-model", SYNC)
         btn.insert_action_group("dbusmenu", item.get_action_group())
 

--- a/examples/vala/simple-bar/widget/Bar.vala
+++ b/examples/vala/simple-bar/widget/Bar.vala
@@ -121,7 +121,7 @@ class SysTray : Gtk.Box {
         var icon = new Astal.Icon() { visible = true };
 
         item.bind_property("tooltip-markup", btn, "tooltip-markup", BindingFlags.SYNC_CREATE);
-        item.bind_property("gicon", icon, "g-icon", BindingFlags.SYNC_CREATE);
+        item.bind_property("gicon", icon, "gicon", BindingFlags.SYNC_CREATE);
         item.bind_property("menu-model", btn, "menu-model", BindingFlags.SYNC_CREATE);
         btn.insert_action_group("dbusmenu", item.action_group);
         item.notify["action-group"].connect(() => {

--- a/lib/astal/gtk3/src/widget/icon.vala
+++ b/lib/astal/gtk3/src/widget/icon.vala
@@ -9,7 +9,16 @@ public class Astal.Icon : Gtk.Image {
     private double size { get; set; default = 14; }
 
     public new Gdk.Pixbuf pixbuf { get; set; }
-    public GLib.Icon g_icon { get; set; }
+  
+    [Version (deprecated = true, deprecated_since = "0.1.0", replacement = "gicon")]
+    public GLib.Icon g_icon { 
+        owned get {
+            return this.gicon;
+        } 
+        set {
+            this.gicon = value;
+        }
+    }
 
     /**
      * Either a named icon or a path to a file.
@@ -57,7 +66,6 @@ public class Astal.Icon : Gtk.Image {
             break;
         case IconType.GICON:
             pixel_size = (int)size;
-            gicon = g_icon;
             break;
 
         }
@@ -86,7 +94,7 @@ public class Astal.Icon : Gtk.Image {
             display_icon.begin();
         });
 
-        notify["g-icon"].connect(() => {
+        notify["gicon"].connect(() => {
             type = IconType.GICON;
             display_icon.begin();
         });

--- a/lib/astal/gtk3/src/widget/icon.vala
+++ b/lib/astal/gtk3/src/widget/icon.vala
@@ -9,13 +9,18 @@ public class Astal.Icon : Gtk.Image {
     private double size { get; set; default = 14; }
 
     public new Gdk.Pixbuf pixbuf { get; set; }
-  
+    
+    private static bool gicon_warned = false;
     [Version (deprecated = true, deprecated_since = "0.1.0", replacement = "gicon")]
     public GLib.Icon g_icon { 
         owned get {
             return this.gicon;
         } 
         set {
+            if( !gicon_warned ) {
+              GLib.warning("g-icon is deprecated. Use gicon instead.");
+              gicon_warned = true;
+            }
             this.gicon = value;
         }
     }


### PR DESCRIPTION
changes the gicon of the Icon widget to directly use the of the parent class. I don't remember why I did it this way in the first place, maybe I was just stupid.

This makes the `g_icon` property useless, to avoid breakages, I made it a proxy for the gicon property of the parent class and marked it as deprecated. But maybe it could be directly removed before the firs release, not sure.

This is an attempt to fix #165