### PR TITLE
Fix documentation typo

### DIFF
--- a/docs/guide/getting-started/installation.md
+++ b/docs/guide/getting-started/installation.md
@@ -22,7 +22,7 @@ maintainer: [@Aylur](https://github.com/Aylur)
 
 Read more about it on the [nix page](./nix#astal)
 
-## Bulding From Source
+## Building From Source
 
 1. Install the following dependencies
 


### PR DESCRIPTION
Changed "bulding" to "building" in a few places, also updated an out-of-date hyperlink.