### PR TITLE
Fix typo in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ You can contribute by:
 - [Suggesting new features](https://github.com/Aylur/astal/issues/new?assignees=&labels=enhancement&projects=&template=feature_request.md&title=)
 - [Reporting bugs](https://github.com/Aylur/astal/issues/new?assignees=&labels=bug&projects=&template=bug_report.md&title=)
 - Improving docs with additional contexts and examples
-  - adding more distros to sections about installations e.g [bulding from source](https://aylur.github.io/astal/guide/getting-started/installation#bulding-libastal-from-source)
+  - adding more distros to sections about installations e.g [building from source](https://aylur.github.io/astal/guide/getting-started/installation#building-from-source)
 - Adding more example projects to [examples](https://github.com/Aylur/astal/tree/main/examples)
 - Adding new language support/binding. For these open a PR for discussions.
 - Adding new libraries e.g support for more wayland compositors

--- a/docs/guide/getting-started/installation.md
+++ b/docs/guide/getting-started/installation.md
@@ -22,7 +22,7 @@ maintainer: [@Aylur](https://github.com/Aylur)
 
 Read more about it on the [nix page](./nix#astal)
 
-## Bulding From Source
+## Building From Source
 
 1. Install the following dependencies
 


### PR DESCRIPTION
Fixed a few instances of 'bulding' to 'building', also updated antiquated hyperlink.