### PR TITLE
nix: add all architectures

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,19 @@
 {
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+
   outputs = {
     self,
     nixpkgs,
   }: let
-    forAllSystems = nixpkgs.lib.genAttrs ["x86_64-linux" "aarch64-linux"];
+    systems = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+    forAllSystems = nixpkgs.lib.genAttrs systems;
   in {
     lib = {
       mkLuaPackage = import ./nix/lua.nix self;
@@ -46,9 +56,5 @@
         inherit self;
         pkgs = nixpkgs.legacyPackages.${system};
       });
-  };
-
-  inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
   };
 }


### PR DESCRIPTION
I needed `astal` to be available on all architectures for [this PR](https://github.com/Aylur/ags/pull/652)