### PR TITLE
fix(nix): place inputs before outputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,4 +1,8 @@
 {
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+
   outputs = {
     self,
     nixpkgs,
@@ -46,9 +50,5 @@
         inherit self;
         pkgs = nixpkgs.legacyPackages.${system};
       });
-  };
-
-  inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
   };
 }


### PR DESCRIPTION
inputs need to be placed before outputs otherwise I get this error
```bash
error: attribute 'aarch64-linux' missing
       at /nix/store/rdrhh93bmsz7a36xw0zi9wyn07wrlacs-source/flake.nix:47:12:
           46|         };
           47|         in astal.packages.${system} // agsPackages
             |            ^
           48|
```
switching them solve the issue.
Also please consider accepting this simple [PR](https://github.com/Aylur/ags/pull/652) to make ags available on `aarch64-linux`.