### PR TITLE
[Gtk3] Fix type of actionGroup prop

### DIFF
--- a/lang/gjs/src/gtk3/astalify.ts
+++ b/lang/gjs/src/gtk3/astalify.ts
@@ -150,6 +150,7 @@ export type ConstructProps<
     css?: string
     cursor?: string
     clickThrough?: boolean
+    actionGroup?: ActionGroup
 }>> & Partial<{
     onDestroy: (self: Self) => unknown
     onDraw: (self: Self) => unknown

--- a/lang/gjs/src/gtk3/astalify.ts
+++ b/lang/gjs/src/gtk3/astalify.ts
@@ -3,6 +3,7 @@ import Astal from "gi://Astal?version=3.0"
 import Gtk from "gi://Gtk?version=3.0"
 import Gdk from "gi://Gdk?version=3.0"
 import GObject from "gi://GObject"
+import Gio from 'gi://Gio?version=2.0';
 import Binding, { type Connectable, type Subscribable } from "../binding.js"
 
 export { BindableProps, mergeBindings }
@@ -196,4 +197,4 @@ type Cursor =
     | "zoom-in"
     | "zoom-out"
 
-type ActionGroup = [prefix: string, actionGroup: Gtk.ActionGroup]
+type ActionGroup = [prefix: string, actionGroup: Gio.ActionGroup]


### PR DESCRIPTION
I saw that in astalify the `ActionGroup` was the one from Gtk but it should be the one from Gio so I fixed that.

Then I wanted to fix the fact that `actionGroup` was giving type errors with JSX but after looking into `Gio.ActionGroup`, I felt it was more accurate to rename the prop to `insertActionGroup` since the `actionGroup` prop isn't setting the `ActionGroup`s of the widget, it's only adding to its list which I felt was misleading.