### PR TITLE
doc: Add valadoc as a dependency for Ubuntu

### DIFF
--- a/docs/guide/getting-started/installation.md
+++ b/docs/guide/getting-started/installation.md
@@ -29,7 +29,7 @@ Read more about it on the [nix page](./nix#astal)
 :::code-group
 
 ```sh [<i class="devicon-archlinux-plain"></i> Arch]
-sudo pacman -Syu meson vala gtk3 gtk-layer-shell gobject-introspection
+sudo pacman -Syu meson vala valadoc gtk3 gtk-layer-shell gobject-introspection
 ```
 
 ```sh [<i class="devicon-fedora-plain"></i> Fedora]
@@ -37,7 +37,7 @@ sudo dnf install meson vala valadoc gtk3-devel gtk-layer-shell-devel gobject-int
 ```
 
 ```sh [<i class="devicon-ubuntu-plain"></i> Ubuntu]
-sudo apt install meson valac libgtk-3-dev libgtk-layer-shell-dev gobject-introspection libgirepository1.0-dev
+sudo apt install meson valac valadoc libgtk-3-dev libgtk-layer-shell-dev gobject-introspection libgirepository1.0-dev
 ```
 
 :::

--- a/docs/guide/libraries/apps.md
+++ b/docs/guide/libraries/apps.md
@@ -80,7 +80,7 @@ foreach (var app in apps.fuzzy_query("firefox")) {
 :::code-group
 
 ```sh [<i class="devicon-archlinux-plain"></i> Arch]
-sudo pacman -Syu meson vala json-glib gobject-introspection
+sudo pacman -Syu meson vala valadoc json-glib gobject-introspection
 ```
 
 ```sh [<i class="devicon-fedora-plain"></i> Fedora]
@@ -88,7 +88,7 @@ sudo dnf install meson vala valadoc json-glib-devel gobject-introspection-devel
 ```
 
 ```sh [<i class="devicon-ubuntu-plain"></i> Ubuntu]
-sudo apt install meson valac libjson-glib-dev gobject-introspection
+sudo apt install meson valac valadoc libjson-glib-dev gobject-introspection
 ```
 
 :::

--- a/docs/guide/libraries/battery.md
+++ b/docs/guide/libraries/battery.md
@@ -53,7 +53,7 @@ print(battery.percentage)
 :::code-group
 
 ```sh [<i class="devicon-archlinux-plain"></i> Arch]
-sudo pacman -Syu meson vala json-glib gobject-introspection
+sudo pacman -Syu meson vala valadoc json-glib gobject-introspection
 ```
 
 ```sh [<i class="devicon-fedora-plain"></i> Fedora]
@@ -61,7 +61,7 @@ sudo dnf install meson vala valadoc json-glib-devel gobject-introspection-devel
 ```
 
 ```sh [<i class="devicon-ubuntu-plain"></i> Ubuntu]
-sudo apt install meson valac libjson-glib-dev gobject-introspection
+sudo apt install meson valac valadoc libjson-glib-dev gobject-introspection
 ```
 
 :::

--- a/docs/guide/libraries/bluetooth.md
+++ b/docs/guide/libraries/bluetooth.md
@@ -60,7 +60,7 @@ end
 :::code-group
 
 ```sh [<i class="devicon-archlinux-plain"></i> Arch]
-sudo pacman -Syu meson vala gobject-introspection
+sudo pacman -Syu meson vala valadoc gobject-introspection
 ```
 
 ```sh [<i class="devicon-fedora-plain"></i> Fedora]
@@ -68,7 +68,7 @@ sudo dnf install meson vala valadoc gobject-introspection-devel
 ```
 
 ```sh [<i class="devicon-ubuntu-plain"></i> Ubuntu]
-sudo apt install meson valac gobject-introspection
+sudo apt install meson valac valadoc gobject-introspection
 ```
 
 :::

--- a/docs/guide/libraries/greet.md
+++ b/docs/guide/libraries/greet.md
@@ -61,7 +61,7 @@ try {
 :::code-group
 
 ```sh [<i class="devicon-archlinux-plain"></i> Arch]
-sudo pacman -Syu meson vala json-glib gobject-introspection
+sudo pacman -Syu meson vala valadoc json-glib gobject-introspection
 ```
 
 ```sh [<i class="devicon-fedora-plain"></i> Fedora]
@@ -69,7 +69,7 @@ sudo dnf install meson vala valadoc json-glib-devel gobject-introspection-devel
 ```
 
 ```sh [<i class="devicon-ubuntu-plain"></i> Ubuntu]
-sudo apt install meson valac libjson-glib-dev gobject-introspection
+sudo apt install meson valac valadoc libjson-glib-dev gobject-introspection
 ```
 
 :::

--- a/docs/guide/libraries/hyprland.md
+++ b/docs/guide/libraries/hyprland.md
@@ -58,7 +58,7 @@ end
 :::code-group
 
 ```sh [<i class="devicon-archlinux-plain"></i> Arch]
-sudo pacman -Syu meson vala json-glib gobject-introspection
+sudo pacman -Syu meson vala valadoc json-glib gobject-introspection
 ```
 
 ```sh [<i class="devicon-fedora-plain"></i> Fedora]
@@ -66,7 +66,7 @@ sudo dnf install meson vala valadoc json-glib-devel gobject-introspection-devel
 ```
 
 ```sh [<i class="devicon-ubuntu-plain"></i> Ubuntu]
-sudo apt install meson valac libjson-glib-dev gobject-introspection
+sudo apt install meson valac valadoc libjson-glib-dev gobject-introspection
 ```
 
 :::

--- a/docs/guide/libraries/mpris.md
+++ b/docs/guide/libraries/mpris.md
@@ -61,7 +61,7 @@ end
 :::code-group
 
 ```sh [<i class="devicon-archlinux-plain"></i> Arch]
-sudo pacman -Syu meson vala gvfs json-glib gobject-introspection
+sudo pacman -Syu meson vala valadoc gvfs json-glib gobject-introspection
 ```
 
 ```sh [<i class="devicon-fedora-plain"></i> Fedora]
@@ -69,7 +69,7 @@ sudo dnf install meson vala valadoc gvfs json-glib-devel gobject-introspection-d
 ```
 
 ```sh [<i class="devicon-ubuntu-plain"></i> Ubuntu]
-sudo apt install meson valac gvfs libjson-glib-dev gobject-introspection
+sudo apt install meson valac valadoc gvfs libjson-glib-dev gobject-introspection
 ```
 
 :::

--- a/docs/guide/libraries/network.md
+++ b/docs/guide/libraries/network.md
@@ -55,7 +55,7 @@ print(network.wifi.ssid)
 :::code-group
 
 ```sh [<i class="devicon-archlinux-plain"></i> Arch]
-sudo pacman -Syu meson vala libnm gobject-introspection
+sudo pacman -Syu meson vala valadoc libnm gobject-introspection
 ```
 
 ```sh [<i class="devicon-fedora-plain"></i> Fedora]
@@ -63,7 +63,7 @@ sudo dnf install meson vala valadoc NetworkManager-libnm-devel gobject-introspec
 ```
 
 ```sh [<i class="devicon-ubuntu-plain"></i> Ubuntu]
-sudo apt install meson valac libnm-dev gobject-introspection
+sudo apt install meson valac valadoc libnm-dev gobject-introspection
 ```
 
 :::

--- a/docs/guide/libraries/notifd.md
+++ b/docs/guide/libraries/notifd.md
@@ -67,7 +67,7 @@ end
 :::code-group
 
 ```sh [<i class="devicon-archlinux-plain"></i> Arch]
-sudo pacman -Syu meson vala gdk-pixbuf2 json-glib gobject-introspection
+sudo pacman -Syu meson vala valadoc gdk-pixbuf2 json-glib gobject-introspection
 ```
 
 ```sh [<i class="devicon-fedora-plain"></i> Fedora]
@@ -75,7 +75,7 @@ sudo dnf install meson vala valadoc gdk-pixbuf2-devel json-glib-devel gobject-in
 ```
 
 ```sh [<i class="devicon-ubuntu-plain"></i> Ubuntu]
-sudo apt install meson valac libgdk-pixbuf-2.0-dev libjson-glib-dev gobject-introspection
+sudo apt install meson valac valadoc libgdk-pixbuf-2.0-dev libjson-glib-dev gobject-introspection
 ```
 
 :::

--- a/docs/guide/libraries/powerprofiles.md
+++ b/docs/guide/libraries/powerprofiles.md
@@ -53,7 +53,7 @@ print(powerprofiles.active_profile)
 :::code-group
 
 ```sh [<i class="devicon-archlinux-plain"></i> Arch]
-sudo pacman -Syu meson vala json-glib gobject-introspection
+sudo pacman -Syu meson vala valadoc json-glib gobject-introspection
 ```
 
 ```sh [<i class="devicon-fedora-plain"></i> Fedora]
@@ -61,7 +61,7 @@ sudo dnf install meson vala valadoc json-glib-devel gobject-introspection-devel
 ```
 
 ```sh [<i class="devicon-ubuntu-plain"></i> Ubuntu]
-sudo apt install meson valac libjson-glib-dev gobject-introspection
+sudo apt install meson valac valadoc libjson-glib-dev gobject-introspection
 ```
 
 :::

--- a/docs/guide/libraries/wireplumber.md
+++ b/docs/guide/libraries/wireplumber.md
@@ -55,7 +55,7 @@ print(audio.default_speaker.volume)
 :::code-group
 
 ```sh [<i class="devicon-archlinux-plain"></i> Arch]
-sudo pacman -Syu meson vala wireplumber gobject-introspection
+sudo pacman -Syu meson vala valadoc wireplumber gobject-introspection
 ```
 
 ```sh [<i class="devicon-fedora-plain"></i> Fedora]


### PR DESCRIPTION
`valadoc` package was missing from the dependency list for ubuntu installation.

These were the compilation logs without installing `valadoc` on ubuntu 24.04:

```
meson install -C build                                                                                   
ninja: Entering directory `/tmp/astal/lib/astal/io/build'
[18/19] Generating AstalIO-0.1.gir with a custom command
FAILED: AstalIO-0.1.gir
/home/goncalo/.pyenv/shims/python3 ../gir.py astal-io AstalIO-0.1.gir --pkg=glib-2.0 --pkg=gio-unix-2.0 --pkg=gobject-2.0 --pkg=gio-2.0 config.vala ../application.vala ../file.vala ../process.vala ../time.vala ../variable.vala
Traceback (most recent call last):
  File "/tmp/astal/lib/astal/io/build/../gir.py", line 67, in <module>
    valadoc(name, gir, args)
  File "/tmp/astal/lib/astal/io/build/../gir.py", line 53, in valadoc
    subprocess.run(cmd, check=True, text=True, capture_output=True)
  File "/usr/lib/python3.12/subprocess.py", line 548, in run
    with Popen(*popenargs, **kwargs) as process:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.12/subprocess.py", line 1955, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'valadoc'
ninja: build stopped: subcommand failed.
Could not rebuild /tmp/astal/lib/astal/io/build 
```

Fixed by `apt install valadoc`