### PR TITLE
gtk4 print error when css loading failed

### DIFF
--- a/lib/astal/gtk4/src/application.vala
+++ b/lib/astal/gtk4/src/application.vala
@@ -143,6 +143,15 @@ public class Astal.Application : Gtk.Application, AstalIO.Application {
     public void apply_css(string style, bool reset = false) {
         var provider = new Gtk.CssProvider();
 
+        provider.parsing_error.connect((section, error) => {
+          critical("CSS Error %s:%zu:%zu: %s\n",
+            section.get_file()?.get_basename() ?? "",
+            section.get_start_location().lines + 1,
+            section.get_start_location().line_chars + 1,
+            error.message
+          );
+        });
+
         if (reset)
             reset_css();
 


### PR DESCRIPTION
the gtk4 version of application does not print an error when the css loading failed. This PR adds an error message. 

eg trying to load this css file:
```css 
/* test.css */
.bar {
  max-height: 5px;
}
```
using `App.apply_css("test.css");`
will result in this error: 
`** (gjs:34209): CRITICAL **: 23:30:25.350: application.vala:147: CSS Error test.css:2:3: No property named "max-height"`

When the css is loaded from a string instead of a file the file name is just omitted so the above error would like this:
`** (gjs:34209): CRITICAL **: 23:30:25.350: application.vala:147: CSS Error :2:3: No property named "max-height"`