### PR TITLE
[Gtk4] Extending Astal Widgets

### DIFF
--- a/lang/gjs/src/gtk4/widget.ts
+++ b/lang/gjs/src/gtk4/widget.ts
@@ -1,11 +1,26 @@
 import Astal from "gi://Astal?version=4.0"
 import Gtk from "gi://Gtk?version=4.0"
-import astalify, { type, type ConstructProps } from "./astalify.js"
+import astalify, { type, type Config, type ConstructProps, type ExtraPropsFunc } from "./astalify.js"
 
 function filter(children: any[]) {
     return children.flat(Infinity).map(ch => ch instanceof Gtk.Widget
         ? ch
         : new Gtk.Label({ visible: true, label: String(ch) }))
+}
+
+function mkOverridable<
+    Widget extends Gtk.Widget,
+    Props extends Gtk.Widget.ConstructorProps = Gtk.Widget.ConstructorProps,
+    Signals extends Record<`on${string}`, Array<unknown>> = Record<`on${string}`, any[]>,
+>(
+    cls: { new(...args: any[]): Widget },
+    config: Partial<Config<Widget>> = {},
+) {
+    return function mkWidget<
+        ExtraProps extends Record<string, unknown> = Record<string, undefined>,
+    >(extraProps = {} as ExtraPropsFunc<Widget, ExtraProps>) {
+        return astalify<Widget, Props, Signals, ExtraProps>(cls, config, extraProps)
+    }
 }
 
 // Box
@@ -15,10 +30,18 @@ Object.defineProperty(Astal.Box.prototype, "children", {
 })
 
 export type BoxProps = ConstructProps<Astal.Box, Astal.Box.ConstructorProps>
-export const Box = astalify<Astal.Box, Astal.Box.ConstructorProps>(Astal.Box, {
+
+const mkBox = mkOverridable<Astal.Box, Astal.Box.ConstructorProps>(Astal.Box, {
     getChildren(self) { return self.get_children() },
     setChildren(self, children) { return self.set_children(filter(children)) },
 })
+
+export const Box = mkBox()
+export function ExtendBox<
+    ExtraProps extends Record<string, unknown> = Record<string, undefined>,
+>(extraProps = {} as ExtraPropsFunc<Astal.Box, ExtraProps>) {
+    return mkBox(extraProps)
+}
 
 // Button
 type ButtonSignals = {
@@ -26,11 +49,20 @@ type ButtonSignals = {
 }
 
 export type ButtonProps = ConstructProps<Gtk.Button, Gtk.Button.ConstructorProps, ButtonSignals>
-export const Button = astalify<Gtk.Button, Gtk.Button.ConstructorProps, ButtonSignals>(Gtk.Button)
+
+const mkButton = mkOverridable<Gtk.Button, Gtk.Button.ConstructorProps, ButtonSignals>(Gtk.Button)
+
+export const Button = mkButton()
+export function ExtendButton<
+    ExtraProps extends Record<string, unknown> = Record<string, undefined>,
+>(extraProps = {} as ExtraPropsFunc<Gtk.Button, ExtraProps>) {
+    return mkButton(extraProps)
+}
 
 // CenterBox
 export type CenterBoxProps = ConstructProps<Gtk.CenterBox, Gtk.CenterBox.ConstructorProps>
-export const CenterBox = astalify<Gtk.CenterBox, Gtk.CenterBox.ConstructorProps>(Gtk.CenterBox, {
+
+const mkCenterBox = mkOverridable<Gtk.CenterBox, Gtk.CenterBox.ConstructorProps>(Gtk.CenterBox, {
     getChildren(box) {
         return [box.startWidget, box.centerWidget, box.endWidget]
     },
@@ -42,6 +74,13 @@ export const CenterBox = astalify<Gtk.CenterBox, Gtk.CenterBox.ConstructorProps>
     },
 })
 
+export const CenterBox = mkCenterBox()
+export function ExtendCenterBox<
+    ExtraProps extends Record<string, unknown> = Record<string, undefined>,
+>(extraProps = {} as ExtraPropsFunc<Gtk.CenterBox, ExtraProps>) {
+    return mkCenterBox(extraProps)
+}
+
 // TODO: CircularProgress
 // TODO: DrawingArea
 
@@ -52,34 +91,67 @@ type EntrySignals = {
 }
 
 export type EntryProps = ConstructProps<Gtk.Entry, Gtk.Entry.ConstructorProps, EntrySignals>
-export const Entry = astalify<Gtk.Entry, Gtk.Entry.ConstructorProps, EntrySignals>(Gtk.Entry, {
+
+const mkEntry = mkOverridable<Gtk.Entry, Gtk.Entry.ConstructorProps, EntrySignals>(Gtk.Entry, {
     getChildren() { return [] },
 })
+
+export const Entry = mkEntry()
+export function ExtendEntry<
+    ExtraProps extends Record<string, unknown> = Record<string, undefined>,
+>(extraProps = {} as ExtraPropsFunc<Gtk.Entry, ExtraProps>) {
+    return mkEntry(extraProps)
+}
 
 // Image
 export type ImageProps = ConstructProps<Gtk.Image, Gtk.Image.ConstructorProps>
-export const Image = astalify<Gtk.Image, Gtk.Image.ConstructorProps>(Gtk.Image, {
+
+const mkImage = mkOverridable<Gtk.Image, Gtk.Image.ConstructorProps>(Gtk.Image, {
     getChildren() { return [] },
 })
 
+export const Image = mkImage()
+export function ExtendImage<
+    ExtraProps extends Record<string, unknown> = Record<string, undefined>,
+>(extraProps = {} as ExtraPropsFunc<Gtk.Image, ExtraProps>) {
+    return mkImage(extraProps)
+}
+
 // Label
 export type LabelProps = ConstructProps<Gtk.Label, Gtk.Label.ConstructorProps>
-export const Label = astalify<Gtk.Label, Gtk.Label.ConstructorProps>(Gtk.Label, {
+
+const mkLabel = mkOverridable<Gtk.Label, Gtk.Label.ConstructorProps>(Gtk.Label, {
     getChildren() { return [] },
     setChildren(self, children) { self.label = String(children) },
 })
 
+export const Label = mkLabel()
+export function ExtendLabel<
+    ExtraProps extends Record<string, unknown> = Record<string, undefined>,
+>(extraProps = {} as ExtraPropsFunc<Gtk.Label, ExtraProps>) {
+    return mkLabel(extraProps)
+}
+
 // LevelBar
 export type LevelBarProps = ConstructProps<Gtk.LevelBar, Gtk.LevelBar.ConstructorProps>
-export const LevelBar = astalify<Gtk.LevelBar, Gtk.LevelBar.ConstructorProps>(Gtk.LevelBar, {
+
+const mkLevelBar = mkOverridable<Gtk.LevelBar, Gtk.LevelBar.ConstructorProps>(Gtk.LevelBar, {
     getChildren() { return [] },
 })
+
+export const LevelBar = mkLevelBar()
+export function ExtendLevelBar<
+    ExtraProps extends Record<string, unknown> = Record<string, undefined>,
+>(extraProps = {} as ExtraPropsFunc<Gtk.LevelBar, ExtraProps>) {
+    return mkLevelBar(extraProps)
+}
 
 // TODO: ListBox
 
 // Overlay
 export type OverlayProps = ConstructProps<Gtk.Overlay, Gtk.Overlay.ConstructorProps>
-export const Overlay = astalify<Gtk.Overlay, Gtk.Overlay.ConstructorProps>(Gtk.Overlay, {
+
+const mkOverlay = mkOverridable<Gtk.Overlay, Gtk.Overlay.ConstructorProps>(Gtk.Overlay, {
     getChildren(self) {
         const children: Array<Gtk.Widget> = []
         let ch = self.get_first_child()
@@ -108,9 +180,24 @@ export const Overlay = astalify<Gtk.Overlay, Gtk.Overlay.ConstructorProps>(Gtk.O
     },
 })
 
+export const Overlay = mkOverlay()
+export function ExtendOverlay<
+    ExtraProps extends Record<string, unknown> = Record<string, undefined>,
+>(extraProps = {} as ExtraPropsFunc<Gtk.Overlay, ExtraProps>) {
+    return mkOverlay(extraProps)
+}
+
 // Revealer
 export type RevealerProps = ConstructProps<Gtk.Revealer, Gtk.Revealer.ConstructorProps>
-export const Revealer = astalify<Gtk.Revealer, Gtk.Revealer.ConstructorProps>(Gtk.Revealer)
+
+const mkRevealer = mkOverridable<Gtk.Revealer, Gtk.Revealer.ConstructorProps>(Gtk.Revealer)
+
+export const Revealer = mkRevealer()
+export function ExtendRevealer<
+    ExtraProps extends Record<string, unknown> = Record<string, undefined>,
+>(extraProps = {} as ExtraPropsFunc<Gtk.Revealer, ExtraProps>) {
+    return mkRevealer(extraProps)
+}
 
 // Slider
 type SliderSignals = {
@@ -118,13 +205,22 @@ type SliderSignals = {
 }
 
 export type SliderProps = ConstructProps<Astal.Slider, Astal.Slider.ConstructorProps, SliderSignals>
-export const Slider = astalify<Astal.Slider, Astal.Slider.ConstructorProps, SliderSignals>(Astal.Slider, {
+
+const mkSlider = mkOverridable<Astal.Slider, Astal.Slider.ConstructorProps, SliderSignals>(Astal.Slider, {
     getChildren() { return [] },
 })
 
+export const Slider = mkSlider()
+export function ExtendSlider<
+    ExtraProps extends Record<string, unknown> = Record<string, undefined>,
+>(extraProps = {} as ExtraPropsFunc<Astal.Slider, ExtraProps>) {
+    return mkSlider(extraProps)
+}
+
 // Stack
 export type StackProps = ConstructProps<Gtk.Stack, Gtk.Stack.ConstructorProps>
-export const Stack = astalify<Gtk.Stack, Gtk.Stack.ConstructorProps>(Gtk.Stack, {
+
+const mkStack = mkOverridable<Gtk.Stack, Gtk.Stack.ConstructorProps>(Gtk.Stack, {
     setChildren(self, children) {
         for (const child of filter(children)) {
             if (child.name != "" && child.name != null) {
@@ -136,19 +232,43 @@ export const Stack = astalify<Gtk.Stack, Gtk.Stack.ConstructorProps>(Gtk.Stack, 
     },
 })
 
+export const Stack = mkStack()
+export function ExtendStack<
+    ExtraProps extends Record<string, unknown> = Record<string, undefined>,
+>(extraProps = {} as ExtraPropsFunc<Gtk.Stack, ExtraProps>) {
+    return mkStack(extraProps)
+}
+
 // Switch
 export type SwitchProps = ConstructProps<Gtk.Switch, Gtk.Switch.ConstructorProps>
-export const Switch = astalify<Gtk.Switch, Gtk.Switch.ConstructorProps>(Gtk.Switch, {
+
+const mkSwitch = mkOverridable<Gtk.Switch, Gtk.Switch.ConstructorProps>(Gtk.Switch, {
     getChildren() { return [] },
 })
 
+export const Switch = mkSwitch()
+export function ExtendSwitch<
+    ExtraProps extends Record<string, unknown> = Record<string, undefined>,
+>(extraProps = {} as ExtraPropsFunc<Gtk.Switch, ExtraProps>) {
+    return mkSwitch(extraProps)
+}
+
 // Window
 export type WindowProps = ConstructProps<Astal.Window, Astal.Window.ConstructorProps>
-export const Window = astalify<Astal.Window, Astal.Window.ConstructorProps>(Astal.Window)
+
+const mkWindow = mkOverridable<Astal.Window, Astal.Window.ConstructorProps>(Astal.Window)
+
+export const Window = mkWindow()
+export function ExtendWindow<
+    ExtraProps extends Record<string, unknown> = Record<string, undefined>,
+>(extraProps = {} as ExtraPropsFunc<Astal.Window, ExtraProps>) {
+    return mkWindow(extraProps)
+}
 
 // MenuButton
 export type MenuButtonProps = ConstructProps<Gtk.MenuButton, Gtk.MenuButton.ConstructorProps>
-export const MenuButton = astalify<Gtk.MenuButton, Gtk.MenuButton.ConstructorProps>(Gtk.MenuButton, {
+
+const mkMenuButton = mkOverridable<Gtk.MenuButton, Gtk.MenuButton.ConstructorProps>(Gtk.MenuButton, {
     getChildren(self) { return [self.popover, self.child] },
     setChildren(self, children) {
         for (const child of filter(children)) {
@@ -161,6 +281,21 @@ export const MenuButton = astalify<Gtk.MenuButton, Gtk.MenuButton.ConstructorPro
     },
 })
 
+export const MenuButton = mkMenuButton()
+export function ExtendMenuButton<
+    ExtraProps extends Record<string, unknown> = Record<string, undefined>,
+>(extraProps = {} as ExtraPropsFunc<Gtk.MenuButton, ExtraProps>) {
+    return mkMenuButton(extraProps)
+}
+
 // Popoper
 export type PopoverProps = ConstructProps<Gtk.Popover, Gtk.Popover.ConstructorProps>
-export const Popover = astalify<Gtk.Popover, Gtk.Popover.ConstructorProps>(Gtk.Popover)
+
+const mkPopover = mkOverridable<Gtk.Popover, Gtk.Popover.ConstructorProps>(Gtk.Popover)
+
+export const Popover = mkPopover()
+export function ExtendPopover<
+    ExtraProps extends Record<string, unknown> = Record<string, undefined>,
+>(extraProps = {} as ExtraPropsFunc<Gtk.Popover, ExtraProps>) {
+    return mkPopover(extraProps)
+}


### PR DESCRIPTION
This allows us to add bindable properties with correct types easily like this:

```tsx
const StyledBox = Widget.ExtendBox<{ css: string }>({
    css: (self) => {
        let _css: string | undefined;
        const provider = new Gtk.CssProvider();

        self.get_style_context().add_provider(
            provider,
            Gtk.STYLE_PROVIDER_PRIORITY_USER,
        );

        return {
            get() {
                return _css;
            },
            set(value) {
                provider.load_from_string(value);
                _css = value;
            },
        };
    },
});

(
    <StyledBox
        css={someVar().as((width) => `* { background: red; min-height: 100px; min-width: ${width}px; }`)}
    />
)
```

I am definitely open to suggestions on how to implement this, but I was pretty happy with this result.