### PR TITLE
[Nix] Expose `girName` of each lib with `passthru`

### DIFF
--- a/nix/mkAstalPkg.nix
+++ b/nix/mkAstalPkg.nix
@@ -77,19 +77,25 @@ in
       inherit pname src version;
       outputs = ["out" "dev" "doc"];
 
-      nativeBuildInputs = with pkgs; [
-        wrapGAppsHook
-        gobject-introspection
-        meson
-        pkg-config
-        ninja
-        vala
-        wayland
-        wayland-scanner
-        python3
-      ];
+      nativeBuildInputs = with pkgs;
+        [
+          wrapGAppsHook
+          gobject-introspection
+          meson
+          pkg-config
+          ninja
+          vala
+          wayland
+          wayland-scanner
+          python3
+        ]
+        ++ nativeBuildInputs;
 
-      propagatedBuildInputs = [pkgs.glib] ++ packages;
+      propagatedBuildInputs = with pkgs;
+        [
+          glib
+        ]
+        ++ packages;
 
       postUnpack = ''
         cp --remove-destination ${../lib/gir.py} $sourceRoot/gir.py


### PR DESCRIPTION
- cleaned up `mkAstalPkg` by grouping the inherits
- fixed `nativeBuildInputs` param not getting passed to the actual resulting derivation
- exposed `girName` with `passthru` so we can easily get it in nix code

I wanted this because I generate my types with nix and the logic to get the girName looks like this right now:
```nix
        girName =
          if package.pname == "astal-wireplumber"
          then "AstalWp-0.1"
          else if package.pname == "astal"
          then "AstalIO-0.1"
          else if package.pname == "astal3"
          then "Astal-3.0"
          else if package.pname == "astal4"
          then "Astal-4.0"
          else if package.pname == "astal-powerprofiles"
          then "AstalPowerProfiles-0.1"
          else if package.pname == "gtk4"
          then "Gtk-4.0"
          else (concatMapStrings capitalise (splitString "-" package.pname)) + "-0.1";
```

and every time some names would change I wouldn't know what was wrong