### PR TITLE
Annotate Vala namespaces to fix gir files

### DIFF
--- a/lib/astal/gtk3/src/config.vala.in
+++ b/lib/astal/gtk3/src/config.vala.in
@@ -1,3 +1,4 @@
+[CCode (gir_namespace = "Astal", gir_version = "@API_VERSION@")]
 namespace Astal {
     public const int MAJOR_VERSION = @MAJOR_VERSION@;
     public const int MINOR_VERSION = @MINOR_VERSION@;

--- a/lib/astal/gtk3/src/meson.build
+++ b/lib/astal/gtk3/src/meson.build
@@ -10,6 +10,7 @@ config = configure_file(
   input: 'config.vala.in',
   output: 'config.vala',
   configuration: {
+    'API_VERSION': api_version,
     'VERSION': meson.project_version(),
     'MAJOR_VERSION': version_split[0],
     'MINOR_VERSION': version_split[1],

--- a/lib/astal/gtk4/src/config.vala.in
+++ b/lib/astal/gtk4/src/config.vala.in
@@ -1,3 +1,4 @@
+[CCode (gir_namespace = "Astal", gir_version = "@API_VERSION@")]
 namespace Astal {
     public const int MAJOR_VERSION = @MAJOR_VERSION@;
     public const int MINOR_VERSION = @MINOR_VERSION@;

--- a/lib/astal/gtk4/src/meson.build
+++ b/lib/astal/gtk4/src/meson.build
@@ -10,6 +10,7 @@ config = configure_file(
   input: 'config.vala.in',
   output: 'config.vala',
   configuration: {
+    'API_VERSION': api_version,
     'VERSION': meson.project_version(),
     'MAJOR_VERSION': version_split[0],
     'MINOR_VERSION': version_split[1],

--- a/lib/astal/io/config.vala.in
+++ b/lib/astal/io/config.vala.in
@@ -1,3 +1,4 @@
+[CCode (gir_namespace = "AstalIO", gir_version = "@API_VERSION@")]
 namespace AstalIO {
     public const int MAJOR_VERSION = @MAJOR_VERSION@;
     public const int MINOR_VERSION = @MINOR_VERSION@;

--- a/lib/astal/io/meson.build
+++ b/lib/astal/io/meson.build
@@ -22,6 +22,7 @@ config = configure_file(
   input: 'config.vala.in',
   output: 'config.vala',
   configuration: {
+    'API_VERSION': api_version,
     'VERSION': meson.project_version(),
     'MAJOR_VERSION': version_split[0],
     'MINOR_VERSION': version_split[1],

--- a/lib/battery/config.vala.in
+++ b/lib/battery/config.vala.in
@@ -1,3 +1,4 @@
+[CCode (gir_namespace = "AstalBattery", gir_version = "@API_VERSION@")]
 namespace AstalBattery {
     public const int MAJOR_VERSION = @MAJOR_VERSION@;
     public const int MINOR_VERSION = @MINOR_VERSION@;

--- a/lib/battery/meson.build
+++ b/lib/battery/meson.build
@@ -25,6 +25,7 @@ config = configure_file(
   input: 'config.vala.in',
   output: 'config.vala',
   configuration: {
+    'API_VERSION': api_version,
     'VERSION': meson.project_version(),
     'MAJOR_VERSION': version_split[0],
     'MINOR_VERSION': version_split[1],

--- a/lib/bluetooth/config.vala.in
+++ b/lib/bluetooth/config.vala.in
@@ -1,3 +1,4 @@
+[CCode (gir_namespace = "AstalBluetooth", gir_version = "@API_VERSION@")]
 namespace AstalBluetooth {
     public const int MAJOR_VERSION = @MAJOR_VERSION@;
     public const int MINOR_VERSION = @MINOR_VERSION@;

--- a/lib/bluetooth/meson.build
+++ b/lib/bluetooth/meson.build
@@ -20,6 +20,7 @@ config = configure_file(
   input: 'config.vala.in',
   output: 'config.vala',
   configuration: {
+    'API_VERSION': api_version,
     'VERSION': meson.project_version(),
     'MAJOR_VERSION': version_split[0],
     'MINOR_VERSION': version_split[1],

--- a/lib/greet/config.vala.in
+++ b/lib/greet/config.vala.in
@@ -1,3 +1,4 @@
+[CCode (gir_namespace = "AstalGreet", gir_version = "@API_VERSION@")]
 namespace AstalGreet {
     public const int MAJOR_VERSION = @MAJOR_VERSION@;
     public const int MINOR_VERSION = @MINOR_VERSION@;

--- a/lib/greet/meson.build
+++ b/lib/greet/meson.build
@@ -25,6 +25,7 @@ config = configure_file(
   input: 'config.vala.in',
   output: 'config.vala',
   configuration: {
+    'API_VERSION': api_version,
     'VERSION': meson.project_version(),
     'MAJOR_VERSION': version_split[0],
     'MINOR_VERSION': version_split[1],

--- a/lib/hyprland/config.vala.in
+++ b/lib/hyprland/config.vala.in
@@ -1,3 +1,4 @@
+[CCode (gir_namespace = "AstalHyprland", gir_version = "@API_VERSION@")]
 namespace AstalHyprland {
     public const int MAJOR_VERSION = @MAJOR_VERSION@;
     public const int MINOR_VERSION = @MINOR_VERSION@;

--- a/lib/hyprland/meson.build
+++ b/lib/hyprland/meson.build
@@ -25,6 +25,7 @@ config = configure_file(
   input: 'config.vala.in',
   output: 'config.vala',
   configuration: {
+    'API_VERSION': api_version,
     'VERSION': meson.project_version(),
     'MAJOR_VERSION': version_split[0],
     'MINOR_VERSION': version_split[1],

--- a/lib/mpris/config.vala.in
+++ b/lib/mpris/config.vala.in
@@ -1,3 +1,4 @@
+[CCode (gir_namespace = "AstalMpris", gir_version = "@API_VERSION@")]
 namespace AstalMpris {
     public const int MAJOR_VERSION = @MAJOR_VERSION@;
     public const int MINOR_VERSION = @MINOR_VERSION@;

--- a/lib/mpris/meson.build
+++ b/lib/mpris/meson.build
@@ -25,6 +25,7 @@ config = configure_file(
   input: 'config.vala.in',
   output: 'config.vala',
   configuration: {
+    'API_VERSION': api_version,
     'VERSION': meson.project_version(),
     'MAJOR_VERSION': version_split[0],
     'MINOR_VERSION': version_split[1],

--- a/lib/network/config.vala.in
+++ b/lib/network/config.vala.in
@@ -1,3 +1,4 @@
+[CCode (gir_namespace = "AstalNetwork", gir_version = "@API_VERSION@")]
 namespace AstalNetwork {
     public const int MAJOR_VERSION = @MAJOR_VERSION@;
     public const int MINOR_VERSION = @MINOR_VERSION@;

--- a/lib/network/meson.build
+++ b/lib/network/meson.build
@@ -20,6 +20,7 @@ config = configure_file(
   input: 'config.vala.in',
   output: 'config.vala',
   configuration: {
+    'API_VERSION': api_version,
     'VERSION': meson.project_version(),
     'MAJOR_VERSION': version_split[0],
     'MINOR_VERSION': version_split[1],

--- a/lib/notifd/config.vala.in
+++ b/lib/notifd/config.vala.in
@@ -1,3 +1,4 @@
+[CCode (gir_namespace = "AstalNotifd", gir_version = "@API_VERSION@")]
 namespace AstalNotifd {
     public const int MAJOR_VERSION = @MAJOR_VERSION@;
     public const int MINOR_VERSION = @MINOR_VERSION@;

--- a/lib/notifd/meson.build
+++ b/lib/notifd/meson.build
@@ -26,6 +26,7 @@ config = configure_file(
   input: 'config.vala.in',
   output: 'config.vala',
   configuration: {
+    'API_VERSION': api_version,
     'VERSION': meson.project_version(),
     'MAJOR_VERSION': version_split[0],
     'MINOR_VERSION': version_split[1],

--- a/lib/powerprofiles/config.vala.in
+++ b/lib/powerprofiles/config.vala.in
@@ -1,3 +1,4 @@
+[CCode (gir_namespace = "AstalPowerProfiles", gir_version = "@API_VERSION@")]
 namespace AstalPowerProfiles {
     public const int MAJOR_VERSION = @MAJOR_VERSION@;
     public const int MINOR_VERSION = @MINOR_VERSION@;

--- a/lib/powerprofiles/meson.build
+++ b/lib/powerprofiles/meson.build
@@ -25,6 +25,7 @@ config = configure_file(
   input: 'config.vala.in',
   output: 'config.vala',
   configuration: {
+    'API_VERSION': api_version,
     'VERSION': meson.project_version(),
     'MAJOR_VERSION': version_split[0],
     'MINOR_VERSION': version_split[1],

--- a/lib/tray/config.vala.in
+++ b/lib/tray/config.vala.in
@@ -1,3 +1,4 @@
+[CCode (gir_namespace = "AstalTray", gir_version = "@API_VERSION@")]
 namespace AstalTray {
     public const int MAJOR_VERSION = @MAJOR_VERSION@;
     public const int MINOR_VERSION = @MINOR_VERSION@;

--- a/lib/tray/meson.build
+++ b/lib/tray/meson.build
@@ -26,6 +26,7 @@ config = configure_file(
   input: 'config.vala.in',
   output: 'config.vala',
   configuration: {
+    'API_VERSION': api_version,
     'VERSION': meson.project_version(),
     'MAJOR_VERSION': version_split[0],
     'MINOR_VERSION': version_split[1],


### PR DESCRIPTION
- Added annotations for GIR Namespace and api version of every vala lib, fixing the missing import of `AstalIO` in generated types for `Astal3` and `Astal4`