### PR TITLE
Update installation.md to include another dependency on Fedora 

### DIFF
--- a/docs/guide/getting-started/installation.md
+++ b/docs/guide/getting-started/installation.md
@@ -33,7 +33,7 @@ sudo pacman -Syu meson vala valadoc gtk3 gtk-layer-shell gobject-introspection
 ```
 
 ```sh [<i class="devicon-fedora-plain"></i> Fedora]
-sudo dnf install meson vala valadoc gtk3-devel gtk-layer-shell-devel gobject-introspection-devel
+sudo dnf install meson vala valadoc gtk3-devel gtk-layer-shell-devel gobject-introspection-devel wayland-protocols-devel
 ```
 
 ```sh [<i class="devicon-ubuntu-plain"></i> Ubuntu]


### PR DESCRIPTION
I added a package : wayland-protocol-devel
This package is required to build astal3 on Fedora and was not included in the package line in the docs.