### PR TITLE
Fix signal names for EventControllerFocus

### DIFF
--- a/lang/gjs/src/gtk4/astalify.ts
+++ b/lang/gjs/src/gtk4/astalify.ts
@@ -160,10 +160,10 @@ function setupControllers<T>(widget: Gtk.Widget, {
         widget.add_controller(focus)
 
         if (onFocusEnter)
-            focus.connect("focus-enter", () => onFocusEnter(widget))
+            focus.connect("enter", () => onFocusEnter(widget))
 
         if (onFocusLeave)
-            focus.connect("focus-leave", () => onFocusLeave(widget))
+            focus.connect("leave", () => onFocusLeave(widget))
     }
 
     if (onKeyPressed || onKeyReleased || onKeyModifier) {


### PR DESCRIPTION
The current signal names cause an error when `onFocusEnter` or `onFocusLeave` is defined on a widget. I have retrieved the proper names from https://docs.gtk.org/gtk4/class.EventControllerFocus.html and renamed the signals.