### PR TITLE
Fix this in default signal handler

### DIFF
--- a/lang/gjs/src/gobject.ts
+++ b/lang/gjs/src/gobject.ts
@@ -142,7 +142,7 @@ export function signal(
             }
             Object.defineProperty(target, `on_${name.replace("-", "_")}`, {
                 value: function (...args: any[]) {
-                    return og(...args)
+                    return og.apply(this, args)
                 },
             })
         }


### PR DESCRIPTION
Using `@signal` with a default handler would not have a bound `this`, which would error with code like this:

```ts
@register()
class Foo extends GObject.Object {
    private _counter = 0;

    @signal()
    incremented() {
        this._counter++;
    }
}
```