### PR TITLE
fix(hyprland): focused_workspace

### DIFF
--- a/lib/hyprland/hyprland.vala
+++ b/lib/hyprland/hyprland.vala
@@ -376,6 +376,8 @@ public class Hyprland : Object {
             case "moveworkspacev2":
                 yield sync_workspaces();
                 yield sync_monitors();
+                focused_workspace = get_workspace(int.parse(args[1]));
+                notify_property("workspaces");
                 break;
 
             case "renameworkspace":


### PR DESCRIPTION
If moving a workspace to another monitor the newly created workspace has the focus. Also notify the workspaces as a property of a workspace has changed.