### PR TITLE
Add doc comments and extra guards to bindings

### DIFF
--- a/lang/gjs/src/binding.ts
+++ b/lang/gjs/src/binding.ts
@@ -8,29 +8,50 @@ export const kebabify = (str: string) => str
     .replaceAll("_", "-")
     .toLowerCase()
 
+/**
+ * A reactive source of a single value.
+ */
 export interface Subscribable<T = unknown> {
+    /**
+     * Subscribe to updates on the value.
+     * @param callback The function to call when the value changes
+     * @returns A function to cancel the subscription
+     */
     subscribe(callback: (value: T) => void): () => void
+    /**
+     * Get the current value (non-reactively).
+     */
     get(): T
     [key: string]: any
 }
 
+/**
+ * A reactive object with many signals that can be connected to individually.
+ * Usually, these are going to be GObjects.
+ */
 export interface Connectable {
     connect(signal: string, callback: (...args: any[]) => unknown): number
     disconnect(id: number): void
     [key: string]: any
 }
 
-export class Binding<Value> {
+export class Binding<Value> implements Subscribable<Value> {
     private transformFn = (v: any) => v
 
     #emitter: Subscribable<Value> | Connectable
     #prop?: string
 
+    /**
+     * Bind to a `Connectable`'s property, preserving its reactivity to be used somewhere else.
+     */
     static bind<
         T extends Connectable,
         P extends keyof T,
     >(object: T, property: P): Binding<T[P]>
 
+    /**
+     * Bind to a `Subscribable`, preserving its reactivity to be used somewhere else.
+     */
     static bind<T>(object: Subscribable<T>): Binding<T>
 
     static bind(emitter: Connectable | Subscribable, prop?: string) {
@@ -42,16 +63,33 @@ export class Binding<Value> {
         this.#prop = prop && kebabify(prop)
     }
 
+    [Symbol.toPrimitive]() {
+        console.warn("Binding implicitly converted to a primitive value. This is almost always a mistake.");
+        return this.toString();
+    }
+
+    /**
+     * This function is mostly here to aid in debugging.
+     * It returns a regular, non-reactive string,
+     * and will not work to reactively use a binding somewhere that expects a plain string.
+     */
     toString() {
         return `Binding<${this.#emitter}${this.#prop ? `, "${this.#prop}"` : ""}>`
     }
 
+    /**
+     * Create a new binding that additionally applies a function on its value.
+     * @param fn The transformation to apply. This should be a pure function, as it can be called at any time.
+     */
     as<T>(fn: (v: Value) => T): Binding<T> {
         const bind = new Binding(this.#emitter, this.#prop)
         bind.transformFn = (v: Value) => fn(this.transformFn(v))
         return bind as unknown as Binding<T>
     }
 
+    /**
+     * Get the binding's current value (non-reactively).
+     */
     get(): Value {
         if (typeof this.#emitter.get === "function")
             return this.transformFn(this.#emitter.get())
@@ -66,6 +104,7 @@ export class Binding<Value> {
 
         throw Error("can not get value of binding")
     }
+
 
     subscribe(callback: (value: Value) => void): () => void {
         if (typeof this.#emitter.subscribe === "function") {

--- a/lang/gjs/src/binding.ts
+++ b/lang/gjs/src/binding.ts
@@ -64,8 +64,8 @@ export class Binding<Value> implements Subscribable<Value> {
     }
 
     [Symbol.toPrimitive]() {
-        console.warn("Binding implicitly converted to a primitive value. This is almost always a mistake.");
-        return this.toString();
+        console.warn("Binding implicitly converted to a primitive value. This is almost always a mistake.")
+        return this.toString()
     }
 
     /**
@@ -104,7 +104,6 @@ export class Binding<Value> implements Subscribable<Value> {
 
         throw Error("can not get value of binding")
     }
-
 
     subscribe(callback: (value: Value) => void): () => void {
         if (typeof this.#emitter.subscribe === "function") {


### PR DESCRIPTION
This is the doc comments commit cherry-picked out of #127, with a couple extra fixes and an implicit conversion warning added on.

Incidentally, this is my first time using `git cherry-pick`, but it seems I've done it correctly (I think).
