### PR TITLE
Add new Gizmo widget helper to create custom widgets in GTK4

### DIFF
--- a/lib/astal/gtk4/src/meson.build
+++ b/lib/astal/gtk4/src/meson.build
@@ -29,6 +29,7 @@ sources = [config] + files(
   'widget/box.vala',
   'widget/slider.vala',
   'widget/window.vala',
+  'widget/gizmo.vala',
   'application.vala',
 )
 

--- a/lib/astal/gtk4/src/widget/gizmo.vala
+++ b/lib/astal/gtk4/src/widget/gizmo.vala
@@ -1,3 +1,8 @@
+/**
+ * Helper widget to create custom widgets
+ *
+ * Based on private GtkGizmo widget
+ */
 public class Astal.Gizmo : Gtk.Widget {
     public delegate void MeasureFunc(
         Gtk.Orientation orientation, int for_size,
@@ -33,6 +38,17 @@ public class Astal.Gizmo : Gtk.Widget {
     private FocusFunc? focus_func;
     private GrabFocusFunc? grab_focus_func;
 
+    /**
+     * Create a new Gizmo
+     *
+     * @param css_name CSS class name. CSS Node
+     * @param measure_func Optional function for measuring the widget
+     * @param allocate_func Optional function for allocating size
+     * @param snapshot_func Optional function for snapshotting the widget
+     * @param contains_func Optional function for checking if a point is within the widget
+     * @param focus_func Optional function for handling focus behaviour
+     * @param grab_focus_func Optional function for grabbing focus
+     */
     public Gizmo(
         string css_name,
         MeasureFunc? measure_func,
@@ -51,6 +67,18 @@ public class Astal.Gizmo : Gtk.Widget {
         this.grab_focus_func = grab_focus_func;
     }
 
+    /**
+     * Create a new Gizmo with a specific role
+     *
+     * @param css_name CSS class name. CSS Node
+     * @param role Accessible role
+     * @param measure_func Optional function for measuring the widget
+     * @param allocate_func Optional function for allocating size
+     * @param snapshot_func Optional function for snapshotting the widget
+     * @param contains_func Optional function for checking if a point is within the widget
+     * @param focus_func Optional function for handling focus behaviour
+     * @param grab_focus_func Optional function for grabbing focus
+     */
     public Gizmo.with_role(
         string css_name,
         Gtk.AccessibleRole role,

--- a/lib/astal/gtk4/src/widget/gizmo.vala
+++ b/lib/astal/gtk4/src/widget/gizmo.vala
@@ -31,12 +31,12 @@ internal class Astal.Gizmo : Gtk.Widget {
 
     public delegate bool GrabFocusFunc();
 
-    private MeasureFunc? measure_func;
-    private AllocateFunc? allocate_func;
-    private SnapshotFunc? snapshot_func;
-    private ContainsFunc? contains_func;
-    private FocusFunc? focus_func;
-    private GrabFocusFunc? grab_focus_func;
+    private unowned MeasureFunc? measure_func;
+    private unowned AllocateFunc? allocate_func;
+    private unowned SnapshotFunc? snapshot_func;
+    private unowned ContainsFunc? contains_func;
+    private unowned FocusFunc? focus_func;
+    private unowned GrabFocusFunc? grab_focus_func;
 
     /**
      * Create a new Gizmo

--- a/lib/astal/gtk4/src/widget/gizmo.vala
+++ b/lib/astal/gtk4/src/widget/gizmo.vala
@@ -1,4 +1,4 @@
-public class Gizmo : Gtk.Widget {
+public class Astal.Gizmo : Gtk.Widget {
     public delegate void MeasureFunc(
         Gtk.Orientation orientation, int for_size,
         out int minimum, out int natural,

--- a/lib/astal/gtk4/src/widget/gizmo.vala
+++ b/lib/astal/gtk4/src/widget/gizmo.vala
@@ -3,7 +3,7 @@
  *
  * Based on private GtkGizmo widget
  */
-public class Astal.Gizmo : Gtk.Widget {
+internal class Astal.Gizmo : Gtk.Widget {
     public delegate void MeasureFunc(
         Gtk.Orientation orientation, int for_size,
         out int minimum, out int natural,

--- a/lib/astal/gtk4/src/widget/gizmo.vala
+++ b/lib/astal/gtk4/src/widget/gizmo.vala
@@ -1,0 +1,124 @@
+public class Gizmo : Gtk.Widget {
+    public delegate void MeasureFunc(
+        Gtk.Orientation orientation, int for_size,
+        out int minimum, out int natural,
+        out int minimum_baseline, out int natural_baseline
+    );
+
+    public delegate void AllocateFunc(
+        int width,
+        int height,
+        int baseline
+    );
+
+    public delegate void SnapshotFunc(
+        Gtk.Snapshot snapshot
+    );
+
+    public delegate bool ContainsFunc(
+        double x,
+        double y
+    );
+
+    public delegate bool FocusFunc(
+        Gtk.DirectionType direction
+    );
+
+    public delegate bool GrabFocusFunc();
+
+    private MeasureFunc? measure_func;
+    private AllocateFunc? allocate_func;
+    private SnapshotFunc? snapshot_func;
+    private ContainsFunc? contains_func;
+    private FocusFunc? focus_func;
+    private GrabFocusFunc? grab_focus_func;
+
+    public Gizmo(
+        string css_name,
+        MeasureFunc? measure_func,
+        AllocateFunc? allocate_func,
+        SnapshotFunc? snapshot_func,
+        ContainsFunc? contains_func,
+        FocusFunc? focus_func,
+        GrabFocusFunc? grab_focus_func
+    ) {
+        Object(css_name: css_name);
+        this.measure_func = measure_func;
+        this.allocate_func = allocate_func;
+        this.snapshot_func = snapshot_func;
+        this.contains_func = contains_func;
+        this.focus_func = focus_func;
+        this.grab_focus_func = grab_focus_func;
+    }
+
+    public Gizmo.with_role(
+        string css_name,
+        Gtk.AccessibleRole role,
+        MeasureFunc? measure_func,
+        AllocateFunc? allocate_func,
+        SnapshotFunc? snapshot_func,
+        ContainsFunc? contains_func,
+        FocusFunc? focus_func,
+        GrabFocusFunc? grab_focus_func
+    ) {
+        Object(css_name: css_name, accessible_role: role);
+        this.measure_func = measure_func;
+        this.allocate_func = allocate_func;
+        this.snapshot_func = snapshot_func;
+        this.contains_func = contains_func;
+        this.focus_func = focus_func;
+        this.grab_focus_func = grab_focus_func;
+    }
+
+    public override void measure(
+        Gtk.Orientation orientation,
+        int for_size,
+        out int minimum,
+        out int natural,
+        out int minimum_baseline,
+        out int natural_baseline
+    ) {
+        if (measure_func != null) {
+            measure_func(orientation, for_size,
+                         out minimum, out natural,
+                         out minimum_baseline, out natural_baseline);
+        } else {
+            minimum = natural = minimum_baseline = natural_baseline = 0;
+        }
+    }
+
+    public override void size_allocate(int width, int height, int baseline) {
+        if (allocate_func != null) {
+            allocate_func(width, height, baseline);
+        }
+    }
+
+    public override void snapshot(Gtk.Snapshot snapshot) {
+        if (snapshot_func != null) {
+            snapshot_func(snapshot);
+        } else {
+            base.snapshot(snapshot);
+        }
+    }
+
+    public override bool contains(double x, double y) {
+        if (contains_func != null) {
+            return contains_func(x, y);
+        }
+        return base.contains(x, y);
+    }
+
+    public override bool focus(Gtk.DirectionType direction) {
+        if (focus_func != null) {
+            return focus_func(direction);
+        }
+        return false;
+    }
+
+    public override bool grab_focus() {
+        if (grab_focus_func != null) {
+            return grab_focus_func();
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
While [gtkgizmo.c](https://gitlab.gnome.org/GNOME/gtk/-/blob/main/gtk/gtkgizmo.c) is quite simple, I need to review the code thoroughly and test it in the field (e.g. [CircularProgress](https://github.com/ARKye03/astal/tree/feat/AstalCircularProgressGizmo)). 


> [!NOTE]
> CircularProgress above will be merged onto https://github.com/ARKye03/astal/tree/feat/CircularProgressWidget, to keep work at #282  