### PR TITLE
Fix broken links

### DIFF
--- a/docs/guide/getting-started/supported-languages.md
+++ b/docs/guide/getting-started/supported-languages.md
@@ -39,13 +39,13 @@ Examples:
 - [Simple Bar](https://github.com/Aylur/astal/tree/main/examples/gtk3/lua/simple-bar)
 ![simple-bar](https://github.com/user-attachments/assets/a306c864-56b7-44c4-8820-81f424f32b9b)
 
-- [Notification Popups](https://github.com/Aylur/astal/tree/main/examples/lua/notifications)
+- [Notification Popups](https://github.com/Aylur/astal/tree/main/examples/gtk3/lua/notifications)
 ![notification-popups](https://github.com/user-attachments/assets/0df0eddc-5c74-4af0-a694-48dc8ec6bb44)
 
-- [Applauncher](https://github.com/Aylur/astal/tree/main/examples/lua/applauncher)
+- [Applauncher](https://github.com/Aylur/astal/tree/main/examples/gtk3/lua/applauncher)
 ![launcher](https://github.com/user-attachments/assets/2695e3bb-dff4-478a-b392-279fe638bfd3)
 
-- [Media Player](https://github.com/Aylur/astal/tree/main/examples/lua/media-player)
+- [Media Player](https://github.com/Aylur/astal/tree/main/examples/gtk3/lua/media-player)
 ![media-player](https://github.com/user-attachments/assets/891e9706-74db-4505-bd83-c3628d7b4fd0)
 
 ## Python


### PR DESCRIPTION
Fixed broken links in `docs/guide/getting-started/supported-languages.md` which pointed to `examples/lua` and not `examples/gtk3/lua`.