### PR TITLE
feat(hyprland): add mirrorOf member of Monitor

### DIFF
--- a/lib/hyprland/hyprland.vala
+++ b/lib/hyprland/hyprland.vala
@@ -215,7 +215,7 @@ public class Hyprland : Object {
 
     // TODO: nag vaxry to make socket events and hyprctl more consistent
     private void init() throws Error {
-        var mons = Json.from_string(message("j/monitors")).get_array();
+        var mons = Json.from_string(message("j/monitors all")).get_array();
         var wrkspcs = Json.from_string(message("j/workspaces")).get_array();
         var clnts = Json.from_string(message("j/clients")).get_array();
 
@@ -270,7 +270,7 @@ public class Hyprland : Object {
     }
 
     public async void sync_monitors() throws Error {
-        var str = yield message_async("j/monitors");
+        var str = yield message_async("j/monitors all");
         var arr = Json.from_string(str).get_array();
         foreach (var obj in arr.get_elements()) {
             var id = (int)obj.get_object().get_int_member("id");

--- a/lib/hyprland/monitor.vala
+++ b/lib/hyprland/monitor.vala
@@ -25,7 +25,7 @@ public class AstalHyprland.Monitor : Object {
     public bool vrr { get; private set; }
     public bool actively_tearing { get; private set; }
     public bool disabled { get; private set; }
-    public string mirror_of {get; private set; }
+    public Monitor? mirror_of {get; private set; }
     public string current_format { get; private set; }
     public Array<string> available_modes { get; private set; }
 
@@ -50,7 +50,6 @@ public class AstalHyprland.Monitor : Object {
         vrr = obj.get_boolean_member("vrr");
         actively_tearing = obj.get_boolean_member("activelyTearing");
         disabled = obj.get_boolean_member("disabled");
-        mirror_of = obj.get_string_member("mirrorOf");
         current_format = obj.get_string_member("currentFormat");
 
         var r = obj.get_array_member("reserved");
@@ -63,6 +62,14 @@ public class AstalHyprland.Monitor : Object {
         foreach (var mode in obj.get_array_member("availableModes").get_elements())
             modes.append_val(mode.get_string());
 
+        // use "none" as default as hpyrland uses this for not mirrored
+        var mirror_id = obj.get_string_member_with_default("mirrorOf", "none");
+        if (mirror_id == "none") {
+            mirror_of = null;
+        }
+        else {
+            mirror_of = hyprland.get_monitor(int.parse(mirror_id));
+        }
         active_workspace = hyprland.get_workspace((int)obj.get_object_member("activeWorkspace").get_int_member("id"));
         special_workspace = hyprland.get_workspace((int)obj.get_object_member("specialWorkspace").get_int_member("id"));
     }

--- a/lib/hyprland/monitor.vala
+++ b/lib/hyprland/monitor.vala
@@ -25,6 +25,7 @@ public class AstalHyprland.Monitor : Object {
     public bool vrr { get; private set; }
     public bool actively_tearing { get; private set; }
     public bool disabled { get; private set; }
+    public string mirror_of {get; private set; }
     public string current_format { get; private set; }
     public Array<string> available_modes { get; private set; }
 
@@ -49,6 +50,7 @@ public class AstalHyprland.Monitor : Object {
         vrr = obj.get_boolean_member("vrr");
         actively_tearing = obj.get_boolean_member("activelyTearing");
         disabled = obj.get_boolean_member("disabled");
+        mirror_of = obj.get_string_member("mirrorOf");
         current_format = obj.get_string_member("currentFormat");
 
         var r = obj.get_array_member("reserved");


### PR DESCRIPTION
For this, it is necessary to use 'monitors all' instead of 'monitors.' 
If this is not done, the 'monitoradded' event will add an empty monitor, and the 'monitorremoved' event will fail with a null error. 
This fixes issues with mirrored displays, but now mirrored monitors are listed under 'monitors' (which they previously were, but not fully and I don't know if this is intended behaviour).