### PR TITLE
feat(mpris) Support for base64-encoded cover arts

### DIFF
--- a/lib/mpris/player.vala
+++ b/lib/mpris/player.vala
@@ -180,17 +180,17 @@ public class AstalMpris.Player : Object {
         }
 
         switch (loop_status) {
-        case Loop.NONE:
-            loop_status = Loop.TRACK;
-            break;
-        case Loop.TRACK:
-            loop_status = Loop.PLAYLIST;
-            break;
-        case Loop.PLAYLIST:
-            loop_status = Loop.NONE;
-            break;
-        default:
-            break;
+            case Loop.NONE:
+                loop_status = Loop.TRACK;
+                break;
+            case Loop.TRACK:
+                loop_status = Loop.PLAYLIST;
+                break;
+            case Loop.PLAYLIST:
+                loop_status = Loop.NONE;
+                break;
+            default:
+                break;
         }
     }
 
@@ -211,14 +211,14 @@ public class AstalMpris.Player : Object {
     private double _get_position() {
         try {
             var reply = proxy.call_sync(
-                                        "org.freedesktop.DBus.Properties.Get",
-                                        new Variant("(ss)",
-                                                    "org.mpris.MediaPlayer2.Player",
-                                                    "Position"
-                                        ),
-                                        DBusCallFlags.NONE,
-                                        -1,
-                                        null
+                "org.freedesktop.DBus.Properties.Get",
+                new Variant("(ss)",
+                    "org.mpris.MediaPlayer2.Player",
+                    "Position"
+                ),
+                DBusCallFlags.NONE,
+                -1,
+                null
             );
 
             var body = reply.get_child_value(0);
@@ -234,7 +234,7 @@ public class AstalMpris.Player : Object {
 
     private void _set_position(double pos) {
         try {
-            proxy.set_position((ObjectPath) trackid, (int64) (pos * 1000000));
+            proxy.set_position((ObjectPath)trackid, (int64)(pos * 1000000));
         } catch (Error error) {
             critical(error.message);
         }
@@ -337,7 +337,7 @@ public class AstalMpris.Player : Object {
      * In languages that cannot introspect this
      * use [method@AstalMpris.Player.get_meta].
      */
-    [CCode(notify = false)] // notified manually in sync
+    [CCode (notify = false)] // notified manually in sync
     public HashTable<string, Variant> metadata { owned get; private set; }
 
     /**
@@ -400,7 +400,7 @@ public class AstalMpris.Player : Object {
      * Lookup a key from [property@AstalMpris.Player:metadata].
      * This method is useful for languages that fail to introspect hashtables.
      */
-    public Variant ? get_meta(string key) {
+    public Variant? get_meta(string key) {
         return metadata.lookup(key);
     }
 
@@ -481,9 +481,9 @@ public class AstalMpris.Player : Object {
             if (metadata.get("mpris:length") != null) {
                 var v = metadata.get("mpris:length");
                 if (v.get_type_string() == "x") {
-                    length = (double) v.get_int64() / 1000000;
+                    length = (double)v.get_int64() / 1000000;
                 } else if (v.get_type_string() == "t") {
-                    length = (double) v.get_uint64() / 1000000;
+                    length = (double)v.get_uint64() / 1000000;
                 }
             } else {
                 length = -1;
@@ -514,6 +514,8 @@ public class AstalMpris.Player : Object {
             int commaIndex = art_url.index_of(",");
             string? baseType = art_url.substring(semicolonIndex + 1, commaIndex - semicolonIndex - 1);
             if (baseType == "base64") {
+                if (!FileUtils.test(COVER_CACHE, FileTest.IS_DIR))
+                    File.new_for_path(COVER_CACHE).make_directory_with_parents(null);
                 uint8[] raw = Base64.decode(art_url.substring(commaIndex + 1));
                 FileUtils.set_data(path, raw);
                 cover_art = path;
@@ -537,18 +539,17 @@ public class AstalMpris.Player : Object {
                 File.new_for_path(COVER_CACHE).make_directory_with_parents(null);
 
             file.copy_async.begin(
-                                  File.new_for_path(path),
-                                  FileCopyFlags.OVERWRITE,
-                                  Priority.DEFAULT,
-                                  null,
-                                  null,
-                                  (_, res) => {
+                File.new_for_path(path),
+                FileCopyFlags.OVERWRITE,
+                Priority.DEFAULT,
+                null,
+                null,
+                (_, res) => {
                 try {
                     file.copy_async.end(res);
                     cover_art = path;
                 } catch (Error err) {
-                    print("\nerror\n");
-                    // critical("Failed to cache cover art with url \"%s\": %s", art_url, err.message);
+                    critical("Failed to cache cover art with url \"%s\": %s", art_url, err.message);
                 }
             });
         } catch (Error err) {

--- a/lib/mpris/player.vala
+++ b/lib/mpris/player.vala
@@ -226,7 +226,7 @@ public class AstalMpris.Player : Object {
                 return -1; // Position not supported
             }
 
-            return (double) body.get_variant().get_int64() / 1000000;
+            return (double)body.get_variant().get_int64() / 1000000;
         } catch (Error err) {
             return -1;
         }
@@ -545,13 +545,14 @@ public class AstalMpris.Player : Object {
                 null,
                 null,
                 (_, res) => {
-                try {
-                    file.copy_async.end(res);
-                    cover_art = path;
-                } catch (Error err) {
-                    critical("Failed to cache cover art with url \"%s\": %s", art_url, err.message);
+                    try {
+                        file.copy_async.end(res);
+                        cover_art = path;
+                    } catch (Error err) {
+                        critical("Failed to cache cover art with url \"%s\": %s", art_url, err.message);
+                    }
                 }
-            });
+            );
         } catch (Error err) {
             critical(err.message);
         }
@@ -615,9 +616,9 @@ public class AstalMpris.Player : Object {
             return;
 
         proxy = Bus.get_proxy_sync(
-                                   BusType.SESSION,
-                                   bus_name,
-                                   "/org/mpris/MediaPlayer2"
+            BusType.SESSION,
+            bus_name,
+            "/org/mpris/MediaPlayer2"
         );
 
         if (proxy.g_name_owner != null) {
@@ -647,13 +648,13 @@ public enum AstalMpris.PlaybackStatus {
 
     internal static PlaybackStatus from_string(string? str) {
         switch (str) {
-        case "Playing" :
-            return PLAYING;
-        case "Paused":
-            return PAUSED;
-        case "Stopped":
-        default:
-            return STOPPED;
+            case "Playing" :
+                return PLAYING;
+            case "Paused":
+                return PAUSED;
+            case "Stopped":
+            default:
+                return STOPPED;
         }
     }
 }
@@ -669,27 +670,27 @@ public enum AstalMpris.Loop {
 
     internal static Loop from_string(string? str) {
         switch (str) {
-        case "None":
-            return NONE;
-        case "Track":
-            return TRACK;
-        case "Playlist":
-            return PLAYLIST;
-        default:
-            return UNSUPPORTED;
+            case "None":
+                return NONE;
+            case "Track":
+                return TRACK;
+            case "Playlist":
+                return PLAYLIST;
+            default:
+                return UNSUPPORTED;
         }
     }
 
     internal string ? to_string() {
         switch (this) {
-        case NONE:
-            return "None";
-        case TRACK:
-            return "Track";
-        case PLAYLIST:
-            return "Playlist";
-        default:
-            return "Unsupported";
+            case NONE:
+                return "None";
+            case TRACK:
+                return "Track";
+            case PLAYLIST:
+                return "Playlist";
+            default:
+                return "Unsupported";
         }
     }
 }
@@ -707,12 +708,12 @@ public enum AstalMpris.Shuffle {
 
     internal string ? to_string() {
         switch (this) {
-        case OFF:
-            return "Off";
-        case ON:
-            return "On";
-        default:
-            return "Unsupported";
+            case OFF:
+                return "Off";
+            case ON:
+                return "On";
+            default:
+                return "Unsupported";
         }
     }
 }

--- a/lib/mpris/player.vala
+++ b/lib/mpris/player.vala
@@ -508,11 +508,11 @@ public class AstalMpris.Player : Object {
             cover_art = null;
             return;
         }
+        string path = COVER_CACHE + "/" + Checksum.compute_for_string(ChecksumType.SHA1, art_url, -1);
         if (art_url.index_of(",") != -1) {
             string? baseType = art_url.substring(art_url.index_of(";") + 1, art_url.index_of(",") - art_url.index_of(";") - 1);
             if (baseType == "base64") {
                 uint8[] raw = Base64.decode(art_url.substring(art_url.index_of(",") + 1));
-                string path = COVER_CACHE + "/" + Checksum.compute_for_string(ChecksumType.SHA1, art_url, -1);
                 FileUtils.set_data(path, raw);
                 cover_art = path;
                 return;
@@ -525,7 +525,6 @@ public class AstalMpris.Player : Object {
             return;
         }
 
-        var path = COVER_CACHE + "/" + Checksum.compute_for_string(ChecksumType.SHA1, art_url, -1);
         if (FileUtils.test(path, FileTest.EXISTS)) {
             cover_art = path;
             return;

--- a/lib/mpris/player.vala
+++ b/lib/mpris/player.vala
@@ -510,9 +510,11 @@ public class AstalMpris.Player : Object {
         }
         string path = COVER_CACHE + "/" + Checksum.compute_for_string(ChecksumType.SHA1, art_url, -1);
         if (art_url.index_of(",") != -1) {
-            string? baseType = art_url.substring(art_url.index_of(";") + 1, art_url.index_of(",") - art_url.index_of(";") - 1);
+            int semicolonIndex = art_url.index_of(";");
+            int commaIndex = art_url.index_of(",");
+            string? baseType = art_url.substring(semicolonIndex + 1, commaIndex - semicolonIndex - 1);
             if (baseType == "base64") {
-                uint8[] raw = Base64.decode(art_url.substring(art_url.index_of(",") + 1));
+                uint8[] raw = Base64.decode(art_url.substring(commaIndex + 1));
                 FileUtils.set_data(path, raw);
                 cover_art = path;
                 return;

--- a/lib/mpris/player.vala
+++ b/lib/mpris/player.vala
@@ -566,7 +566,7 @@ public class AstalMpris.Player : Object {
         return str == null ? "" : str;
     }
 
-    private string ? join_strv(string key, string sep) {
+    private string? join_strv(string key, string sep) {
         if (metadata.get(key) == null)
             return null;
 
@@ -648,7 +648,7 @@ public enum AstalMpris.PlaybackStatus {
 
     internal static PlaybackStatus from_string(string? str) {
         switch (str) {
-            case "Playing" :
+            case "Playing":
                 return PLAYING;
             case "Paused":
                 return PAUSED;
@@ -681,7 +681,7 @@ public enum AstalMpris.Loop {
         }
     }
 
-    internal string ? to_string() {
+    internal string? to_string() {
         switch (this) {
             case NONE:
                 return "None";
@@ -706,7 +706,7 @@ public enum AstalMpris.Shuffle {
         return b ? Shuffle.ON : Shuffle.OFF;
     }
 
-    internal string ? to_string() {
+    internal string? to_string() {
         switch (this) {
             case OFF:
                 return "Off";


### PR DESCRIPTION
Implementing request from #177. While base64 images aren't supported directly, they still can be decoded.

I also changed the COVER_CACHE to "/tmp/astal/mpris", just for transparency and simplicity (nobody will realistically use the whole /tmp for cover arts)