### PR TITLE
nix: update appmenu-glib-translator version

### DIFF
--- a/lib/tray/default.nix
+++ b/lib/tray/default.nix
@@ -6,13 +6,13 @@
   vala-panel-appmenu = pkgs.fetchFromGitLab {
     owner = "vala-panel-project";
     repo = "vala-panel-appmenu";
-    rev = "24.05";
-    hash = "sha256-8GWauw7r3zKhvGF2TNOI8GDVctUFDhtG/Vy1cNUpsVo=";
+    rev = "25.04";
+    hash = "sha256-v5J3nwViNiSKRPdJr+lhNUdKaPG82fShPDlnmix5tlY=";
   };
 
   appmenu-glib-translator = pkgs.stdenv.mkDerivation {
     pname = "appmenu-glib-translator";
-    version = "24.05";
+    version = "25.04";
 
     src = "${vala-panel-appmenu}/subprojects/appmenu-glib-translator";
 


### PR DESCRIPTION
updates appmenu-glib-trasnlator to the newest version for nix.

should be fine, but as I don't really use nix, i try to avoid to pushing nix related stuff directly to main.