### PR TITLE
fix: generating types would fail without libgee

### DIFF
--- a/examples/gtk4/simple-bar/js/flake.nix
+++ b/examples/gtk4/simple-bar/js/flake.nix
@@ -42,11 +42,11 @@
       name = "simple-bar";
       src = ./.;
       inherit nativeBuildInputs;
-      buildInputs = astalPackages ++ [pkgs.gjs];
+      buildInputs = astalPackages ++ [pkgs.gjs pkgs.libgee];
     };
 
     devShells.${system}.default = pkgs.mkShell {
-      packages = nativeBuildInputs ++ astalPackages ++ [pkgs.gjs];
+      packages = nativeBuildInputs ++ astalPackages ++ [pkgs.gjs pkgs.libgee];
     };
   };
 }


### PR DESCRIPTION
Before this fix:
```
Error: Failed to import Gee in GCalc, not installed or accessible.
    at GirModule.assertInstalledImport (file:///home/redacted/.npm/_npx/4001ac8ae3bf4948/node_modules/@ts-for-gir/lib/lib/gir-module.js:279:19)
    at IntrospectedRecord.isSimpleType (file:///home/redacted/.npm/_npx/4001ac8ae3bf4948/node_modules/@ts-for-gir/lib/lib/gir/class.js:821:45)
    at file:///home/redacted/.npm/_npx/4001ac8ae3bf4948/node_modules/@ts-for-gir/lib/lib/gir/class.js:851:54
    at Array.every (<anonymous>)
    at IntrospectedRecord.isSimple (file:///home/redacted/.npm/_npx/4001ac8ae3bf4948/node_modules/@ts-for-gir/lib/lib/gir/class.js:851:38)
    at IntrospectedRecord.isSimpleWithoutPointers (file:///home/redacted/.npm/_npx/4001ac8ae3bf4948/node_modules/@ts-for-gir/lib/lib/gir/class.js:858:19)
    at resolveMainConstructor (file:///home/redacted/.npm/_npx/4001ac8ae3bf4948/node_modules/@ts-for-gir/lib/lib/validators/class.js:172:37)
    at chainVisitors (file:///home/redacted/.npm/_npx/4001ac8ae3bf4948/node_modules/@ts-for-gir/lib/lib/validators/class.js:208:23)
    at ClassVisitor.visitRecord (file:///home/redacted/.npm/_npx/4001ac8ae3bf4948/node_modules/@ts-for-gir/lib/lib/validators/class.js:215:29)
    at IntrospectedRecord.accept (file:///home/redacted/.npm/_npx/4001ac8ae3bf4948/node_modules/@ts-for-gir/lib/lib/gir/class.js:662:37)
```

Now it generates types succesfully