### PR TITLE
fix: stop_poll and arg assumption

### DIFF
--- a/lang/lua/astal/gtk3/app.lua
+++ b/lang/lua/astal/gtk3/app.lua
@@ -67,7 +67,7 @@ function Astal.Application:start(config)
 
     app.on_activate = function()
         if type(config.main) == "function" then
-            config.main(table.unpack(arg))
+            config.main(table.unpack(arg or {}))
         end
         if config.hold then
             self:hold()
@@ -78,7 +78,7 @@ function Astal.Application:start(config)
     if err ~= nil then
         return config.client(function(msg)
             return AstalIO.send_request(self.instance_name, msg)
-        end, table.unpack(arg))
+        end, table.unpack(arg or {}))
     end
 
     self:run(nil)

--- a/lang/lua/astal/variable.lua
+++ b/lang/lua/astal/variable.lua
@@ -113,7 +113,7 @@ end
 
 function Variable:stop_poll()
     if self:is_polling() then
-        self._poll.cancel()
+        self._poll:cancel()
     end
     self._poll = nil
 end


### PR DESCRIPTION
Fixed bug with variable:stop_poll
Assumption that arg is always defined, custom interpreters and runtimes like debuggers may alter this.