### PR TITLE
feat(river): add layout protocol support

### DIFF
--- a/lib/river/include/astal-river.h.in
+++ b/lib/river/include/astal-river.h.in
@@ -3,14 +3,24 @@
 
 #include <glib-object.h>
 
-
 #define ASTAL_RIVER_MAJOR_VERSION @MAJOR_VERSION@
 #define ASTAL_RIVER_MINOR_VERSION @MINOR_VERSION@
 #define ASTAL_RIVER_MICRO_VERSION @MICRO_VERSION@
 #define ASTAL_RIVER_VERSION "@VERSION@"
 
-
 G_BEGIN_DECLS
+
+#define ASTAL_RIVER_TYPE_GEOMETRY (astal_river_geometry_get_type())
+
+typedef struct {
+    guint x, y, width, height;
+} AstalRiverGeometry;
+
+GType astal_river_geometry_get_type(void);
+
+AstalRiverGeometry *astal_river_geometry_copy(AstalRiverGeometry *geometry);
+
+void astal_river_geometry_free(AstalRiverGeometry *geometry);
 
 GType astal_river_transform_get_type();
 #define ASTAL_RIVER_TYPE_TRANSFORM (astal_river_transform_get_type())
@@ -26,6 +36,9 @@ typedef enum {
     ASTAL_RIVER_TRANSFORM_FLIPPED_ROTATE_270_DEG
 } AstalRiverTransform;
 
+#define ASTAL_RIVER_TYPE_LAYOUT (astal_river_layout_get_type())
+
+G_DECLARE_FINAL_TYPE(AstalRiverLayout, astal_river_layout, ASTAL_RIVER, LAYOUT, GObject)
 
 #define ASTAL_RIVER_TYPE_OUTPUT (astal_river_output_get_type())
 
@@ -41,25 +54,24 @@ gchar *astal_river_output_get_focused_view(AstalRiverOutput *self);
 
 guint astal_river_output_get_focused_tags(AstalRiverOutput *self);
 
-void astal_river_output_set_focused_tags(AstalRiverOutput* self, guint tags);
+void astal_river_output_set_focused_tags(AstalRiverOutput *self, guint tags);
 
 guint astal_river_output_get_urgent_tags(AstalRiverOutput *self);
 
 guint astal_river_output_get_occupied_tags(AstalRiverOutput *self);
 
-const gchar* astal_river_output_get_description(AstalRiverOutput* self);
-const gchar* astal_river_output_get_make(AstalRiverOutput* self);
-const gchar* astal_river_output_get_model(AstalRiverOutput* self);
+const gchar *astal_river_output_get_description(AstalRiverOutput *self);
+const gchar *astal_river_output_get_make(AstalRiverOutput *self);
+const gchar *astal_river_output_get_model(AstalRiverOutput *self);
 
-gint astal_river_output_get_x(AstalRiverOutput* self);
-gint astal_river_output_get_y(AstalRiverOutput* self);
-gint astal_river_output_get_width(AstalRiverOutput* self);
-gint astal_river_output_get_height(AstalRiverOutput* self);
-gint astal_river_output_get_physical_width(AstalRiverOutput* self);
-gint astal_river_output_get_physical_height(AstalRiverOutput* self);
-gint astal_river_output_get_scale_factor(AstalRiverOutput* self);
-gdouble astal_river_output_get_refresh_rate(AstalRiverOutput* self);
-
+gint astal_river_output_get_x(AstalRiverOutput *self);
+gint astal_river_output_get_y(AstalRiverOutput *self);
+gint astal_river_output_get_width(AstalRiverOutput *self);
+gint astal_river_output_get_height(AstalRiverOutput *self);
+gint astal_river_output_get_physical_width(AstalRiverOutput *self);
+gint astal_river_output_get_physical_height(AstalRiverOutput *self);
+gint astal_river_output_get_scale_factor(AstalRiverOutput *self);
+gdouble astal_river_output_get_refresh_rate(AstalRiverOutput *self);
 
 #define ASTAL_RIVER_TYPE_RIVER (astal_river_river_get_type())
 
@@ -80,6 +92,8 @@ gchar *astal_river_river_get_focused_output(AstalRiverRiver *self);
 
 gchar *astal_river_river_get_mode(AstalRiverRiver *self);
 
+AstalRiverLayout *astal_river_river_new_layout(AstalRiverRiver *self, const gchar *namespace);
+
 /**
  * AstalRiverCommandCallback:
  * @success: a #gboolean indicating whether the command was executed successfully
@@ -91,6 +105,34 @@ typedef void (*AstalRiverCommandCallback)(gboolean success, const gchar *msg);
 
 void astal_river_river_run_command_async(AstalRiverRiver *self, gint length, const gchar **cmd,
                                          AstalRiverCommandCallback callback);
+
+/**
+ * AstalRiverLayoutDemandCallback:
+ * @self: an #AstalRiverLayout instance
+ * @output: an #AstalRiverOutput instance for which the layout is being demanded
+ * @view_count: the number of views currently on the output
+ * @usable_width: the usable width of the output for layout
+ * @usable_height: the usable height of the output for layout
+ * @layout_name: (out) (transfer full): the name for the the layout provided by this callback
+ * @geometries: (out) (transfer full) (element-type AstalRiverGeometry): a list of
+ * #AstalRiverGeometry that will be used for the layout for of the views
+ * @user_data: user data passed to the callback
+ *
+ * A callback function that is called when the layout manager needs to determine the layout for a
+ * given output.
+ *
+ */
+typedef void (*AstalRiverLayoutDemandCallback)(AstalRiverLayout *self, AstalRiverOutput *output,
+                                               guint view_count, guint usable_width,
+                                               guint usable_height, gchar **layout_name,
+                                               GList **geometries, gpointer user_data);
+
+const gchar *astal_river_layout_get_namespace(AstalRiverLayout *self);
+
+void astal_river_layout_set_layout_demand_callback(AstalRiverLayout *self,
+                                                   AstalRiverLayoutDemandCallback callback,
+                                                   gpointer user_data,
+                                                   GDestroyNotify destroy_notify);
 
 G_END_DECLS
 

--- a/lib/river/include/astal-river.h.in
+++ b/lib/river/include/astal-river.h.in
@@ -3,10 +3,12 @@
 
 #include <glib-object.h>
 
+// clang-format off
 #define ASTAL_RIVER_MAJOR_VERSION @MAJOR_VERSION@
 #define ASTAL_RIVER_MINOR_VERSION @MINOR_VERSION@
 #define ASTAL_RIVER_MICRO_VERSION @MICRO_VERSION@
 #define ASTAL_RIVER_VERSION "@VERSION@"
+// clang-format on
 
 G_BEGIN_DECLS
 

--- a/lib/river/include/river-private.h
+++ b/lib/river/include/river-private.h
@@ -5,6 +5,7 @@
 
 #include "astal-river.h"
 #include "river-control-unstable-v1-client.h"
+#include "river-layout-v3-client.h"
 #include "river-status-unstable-v1-client.h"
 
 G_BEGIN_DECLS
@@ -17,6 +18,9 @@ AstalRiverOutput *astal_river_output_new(guint id, struct wl_output *wl_output,
 struct wl_output *astal_river_output_get_wl_output(AstalRiverOutput *self);
 void astal_river_output_set_focused_view(AstalRiverOutput *self, const gchar *focused_view);
 
+AstalRiverLayout *astal_river_layout_new(AstalRiverRiver *river,
+                                         struct river_layout_manager_v3 *layout_manager,
+                                         struct wl_display *wl_display, const gchar *namespace);
 G_END_DECLS
 
 #endif  // !ASTAL_RIVER_OUTPUT_PRIVATE_H

--- a/lib/river/meson.build
+++ b/lib/river/meson.build
@@ -5,7 +5,11 @@ project(
   default_options: ['c_std=gnu11', 'warning_level=3', 'prefix=/usr'],
 )
 
-add_project_arguments(['-Wno-pedantic', '-Wno-unused-parameter'], language: 'c')
+add_project_arguments([
+  '-Wno-pedantic',
+  '-Wno-unused-parameter',
+  '-DG_LOG_DOMAIN="AstalRiver"',
+], language: 'c')
 
 version_split = meson.project_version().split('.')
 lib_so_version = version_split[0] + '.' + version_split[1]

--- a/lib/river/protocols/meson.build
+++ b/lib/river/protocols/meson.build
@@ -1,6 +1,10 @@
 wayland_scanner = find_program('wayland-scanner')
 
-protocols = ['river-status-unstable-v1.xml', 'river-control-unstable-v1.xml']
+protocols = [
+  'river-status-unstable-v1.xml',
+  'river-layout-v3.xml',
+  'river-control-unstable-v1.xml'
+]
 
 gen_client_header = generator(
   wayland_scanner,

--- a/lib/river/protocols/river-layout-v3.xml
+++ b/lib/river/protocols/river-layout-v3.xml
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="river_layout_v3">
+  <copyright>
+    Copyright 2020-2021 The River Developers
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+  </copyright>
+
+  <description summary="let clients propose view positions and dimensions">
+    This protocol specifies a way for clients to propose arbitrary positions
+    and dimensions for a set of views on a specific output of a compositor
+    through the river_layout_v3 object.
+
+    Layouts are a strictly linear list of views, the position and dimensions
+    of which are supplied by the client. Any complex underlying data structure
+    a client may use when generating the layout is lost in transmission. This
+    is an intentional limitation.
+
+    Additionally, this protocol allows the compositor to deliver arbitrary
+    user-provided commands associated with a layout to clients. A client
+    may use these commands to implement runtime configuration/control, or
+    may ignore them entirely. How the user provides these commands to the
+    compositor is not specified by this protocol and left to compositor policy.
+
+    Warning! The protocol described in this file is currently in the
+    testing phase. Backward compatible changes may be added together with
+    the corresponding interface version bump. Backward incompatible changes
+    can only be done by creating a new major version of the extension.
+  </description>
+
+  <interface name="river_layout_manager_v3" version="2">
+    <description summary="manage river layout objects">
+      A global factory for river_layout_v3 objects.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the river_layout_manager object">
+        This request indicates that the client will not use the
+        river_layout_manager object any more. Objects that have been created
+        through this instance are not affected.
+      </description>
+    </request>
+
+    <request name="get_layout">
+      <description summary="create a river_layout_v3 object">
+        This creates a new river_layout_v3 object for the given wl_output.
+
+        All layout related communication is done through this interface.
+
+        The namespace is used by the compositor to decide which river_layout_v3
+        object will receive layout demands for the output.
+
+        The namespace is required to be be unique per-output. Furthermore,
+        two separate clients may not share a namespace on separate outputs. If
+        these conditions are not upheld, the the namespace_in_use event will
+        be sent directly after creation of the river_layout_v3 object.
+      </description>
+      <arg name="id" type="new_id" interface="river_layout_v3"/>
+      <arg name="output" type="object" interface="wl_output"/>
+      <arg name="namespace" type="string" summary="namespace of the layout object"/>
+    </request>
+  </interface>
+
+  <interface name="river_layout_v3" version="2">
+    <description summary="receive and respond to layout demands">
+      This interface allows clients to receive layout demands from the
+      compositor for a specific output and subsequently propose positions and
+      dimensions of individual views.
+    </description>
+
+    <enum name="error">
+      <entry name="count_mismatch" value="0" summary="number of
+        proposed dimensions does not match number of views in layout"/>
+      <entry name="already_committed" value="1" summary="the layout demand with
+        the provided serial was already committed"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the river_layout_v3 object">
+        This request indicates that the client will not use the river_layout_v3
+        object any more.
+      </description>
+    </request>
+
+    <event name="namespace_in_use">
+      <description summary="the requested namespace is already in use">
+        After this event is sent, all requests aside from the destroy event
+        will be ignored by the server. If the client wishes to try again with
+        a different namespace they must create a new river_layout_v3 object.
+      </description>
+    </event>
+
+    <event name="layout_demand">
+      <description summary="the compositor requires a layout">
+        The compositor sends this event to inform the client that it requires a
+        layout for a set of views.
+
+        The usable width and height indicate the space in which the client
+        can safely position views without interfering with desktop widgets
+        such as panels.
+
+        The serial of this event is used to identify subsequent requests as
+        belonging to this layout demand. Beware that the client might need
+        to handle multiple layout demands at the same time.
+
+        The server will ignore responses to all but the most recent layout
+        demand. Thus, clients are only required to respond to the most recent
+        layout_demand received. If a newer layout_demand is received before
+        the client has finished responding to an old demand, the client should
+        abort work on the old demand as any further work would be wasted.
+      </description>
+      <arg name="view_count" type="uint" summary="number of views in the layout"/>
+      <arg name="usable_width" type="uint" summary="width of the usable area"/>
+      <arg name="usable_height" type="uint" summary="height of the usable area"/>
+      <arg name="tags" type="uint" summary="tags of the output, 32-bit bitfield"/>
+      <arg name="serial" type="uint" summary="serial of the layout demand"/>
+    </event>
+
+    <request name="push_view_dimensions">
+      <description summary="propose dimensions of the next view">
+        This request proposes a size and position for a view in the layout demand
+        with matching serial.
+
+        A client must send this request for every view that is part of the
+        layout demand. The number of views in the layout is given by the
+        view_count argument of the layout_demand event. Pushing too many or
+        too few view dimensions is a protocol error.
+
+        The x and y coordinates are relative to the usable area of the output,
+        with (0,0) as the top left corner.
+      </description>
+      <arg name="x" type="int" summary="x coordinate of view"/>
+      <arg name="y" type="int" summary="y coordinate of view"/>
+      <arg name="width" type="uint" summary="width of view"/>
+      <arg name="height" type="uint" summary="height of view"/>
+      <arg name="serial" type="uint" summary="serial of layout demand"/>
+    </request>
+
+    <request name="commit">
+      <description summary="commit a layout">
+        This request indicates that the client is done pushing dimensions
+        and the compositor may apply the layout. This completes the layout
+        demand with matching serial, any other requests sent with the serial
+        are a protocol error.
+
+        The layout_name argument is a user-facing name or short description
+        of the layout that is being committed. The compositor may for example
+        display this on a status bar, though what exactly is done with it is
+        left to the compositor's discretion.
+
+        The compositor is free to use this proposed layout however it chooses,
+        including ignoring it.
+      </description>
+      <arg name="layout_name" type="string" summary="name of committed layout"/>
+      <arg name="serial" type="uint" summary="serial of layout demand"/>
+    </request>
+
+    <event name="user_command">
+      <description summary="a command sent by the user">
+        This event informs the client of a command sent to it by the user.
+
+        The semantic meaning of the command is left for the client to
+        decide. It is also free to ignore it entirely if it so chooses.
+
+        A layout_demand will be sent after this event if the compositor is
+        currently using this layout object to arrange the output.
+
+        If version 2 or higher of the river_layout_v3 object is bound, the
+        user_command_tags event is guaranteed to be sent directly before the
+        user_command event.
+      </description>
+      <arg name="command" type="string"/>
+    </event>
+
+    <event name="user_command_tags" since="2">
+      <description summary="a command sent by the user">
+        If version 2 or higher of the river_layout_v3 object is bound, this
+        event will be sent directly before every user_command event. This allows
+        layout generators to be aware of the active tags when a user command is
+        sent. This is necessary for generators wanting to keep settings on a
+        per-tag basis.
+      </description>
+      <arg name="tags" type="uint" summary="tags of the output, 32-bit bitfield"/>
+    </event>
+  </interface>
+</protocol>

--- a/lib/river/src/astal-river.c
+++ b/lib/river/src/astal-river.c
@@ -13,7 +13,8 @@ void print_json(AstalRiverRiver* river) {
 
     gchar* json_str = json_to_string(json, FALSE);
     g_print("%s\n", json_str);
-    g_free(json);
+    json_node_free(json);
+    g_free(json_str);
 }
 
 int main(int argc, char** argv) {

--- a/lib/river/src/meson.build
+++ b/lib/river/src/meson.build
@@ -1,5 +1,6 @@
 srcs = files(
   'river-output.c',
+  'river-layout.c',
   'river.c'
 )
 

--- a/lib/river/src/river-layout.c
+++ b/lib/river/src/river-layout.c
@@ -1,0 +1,297 @@
+#include <gio/gio.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <wayland-client-protocol.h>
+
+#include "astal-river.h"
+#include "glib-object.h"
+#include "glib.h"
+#include "river-layout-v3-client.h"
+#include "river-private.h"
+
+G_DEFINE_BOXED_TYPE(AstalRiverGeometry, astal_river_geometry, astal_river_geometry_copy,
+                    astal_river_geometry_free)
+
+/**
+ * astal_river_geometry_copy
+ * @geometry: the AstalRiverGeometry to copy
+ *
+ * Creates a copy of the given AstalRiverGeometry.
+ *
+ */
+AstalRiverGeometry* astal_river_geometry_copy(AstalRiverGeometry* geometry) {
+    AstalRiverGeometry* new_geometry = g_new(AstalRiverGeometry, 1);
+    new_geometry->x = geometry->x;
+    new_geometry->y = geometry->y;
+    new_geometry->width = geometry->width;
+    new_geometry->height = geometry->height;
+    return new_geometry;
+}
+
+/**
+ * astal_river_geometry_free
+ * @geometry: the AstalRiverGeometry to free
+ *
+ * Frees the given AstalRiverGeometry.
+ *
+ */
+void astal_river_geometry_free(AstalRiverGeometry* geometry) { g_free(geometry); }
+
+struct _AstalRiverLayout {
+    GObject parent_instance;
+
+    gchar* namespace;
+};
+
+typedef struct {
+    AstalRiverRiver* river;
+
+    GHashTable* layouts;
+
+    struct river_layout_manager_v3* layout_manager;
+    struct wl_display* wl_display;
+
+    AstalRiverLayoutDemandCallback layout_demand_callback;
+    GDestroyNotify layout_demand_destroy;
+    void* layout_demand_user_data;
+
+} AstalRiverLayoutPrivate;
+
+G_DEFINE_FINAL_TYPE_WITH_PRIVATE(AstalRiverLayout, astal_river_layout, G_TYPE_OBJECT);
+
+typedef enum {
+    ASTAL_RIVER_LAYOUT_PROP_NAMESPACE = 1,
+    ASTAL_RIVER_LAYOUT_N_PROPERTIES
+} AstalRiverLayoutProperties;
+
+typedef enum {
+    ASTAL_RIVER_LAYOUT_SIGNAL_NAMESPACE_IN_USE,
+    ASTAL_RIVER_LAYOUT_N_SIGNALS
+} AstalRiverLayoutSignals;
+
+static guint astal_river_layout_signals[ASTAL_RIVER_LAYOUT_N_SIGNALS] = {
+    0,
+};
+
+static GParamSpec* astal_river_layout_properties[ASTAL_RIVER_LAYOUT_N_PROPERTIES] = {
+    NULL,
+};
+
+struct river_layout_data {
+    AstalRiverLayout* layout;
+    AstalRiverOutput* output;
+    struct river_layout_v3* river_layout;
+};
+
+void astal_river_layout_data_free(struct river_layout_data* data) {
+    if (data->layout) {
+        river_layout_v3_destroy(data->river_layout);
+    }
+    g_free(data);
+}
+
+/**
+ *  AstalRiverLayout
+ *
+ *  handles the layout of windows.
+ */
+
+/**
+ * astal_river_layout_get_namespace
+ * @self: the AstalRiverLayout object
+ *
+ * the namespace of the layout
+ *
+ * Returns: (transfer none) (nullable): the namespace of the layout
+ */
+const gchar* astal_river_layout_get_namespace(AstalRiverLayout* self) { return self->namespace; }
+
+/**
+ * astal_river_layout_set_layout_demand_callback
+ * @self: the AstalRiverLayout object
+ * @callback: (scope notified): the callback to be called when a layout demand is made
+ * @user_data: user data to be passed to the callback
+ * @destroy_notify: a function to destroy the user data when it is no longer needed
+ *
+ * Sets the callback to be called when a layout demand is made.
+ */
+void astal_river_layout_set_layout_demand_callback(AstalRiverLayout* self,
+                                                   AstalRiverLayoutDemandCallback callback,
+                                                   gpointer user_data,
+                                                   GDestroyNotify destroy_notify) {
+    AstalRiverLayoutPrivate* priv = astal_river_layout_get_instance_private(self);
+    if (priv->layout_demand_destroy) {
+        priv->layout_demand_destroy(priv->layout_demand_user_data);
+    }
+    priv->layout_demand_callback = callback;
+    priv->layout_demand_user_data = user_data;
+    priv->layout_demand_destroy = destroy_notify;
+}
+
+static void astal_river_layout_set_property(GObject* object, guint property_id, const GValue* value,
+                                            GParamSpec* pspec) {
+    AstalRiverLayout* self = ASTAL_RIVER_LAYOUT(object);
+
+    switch (property_id) {
+        case ASTAL_RIVER_LAYOUT_PROP_NAMESPACE:
+            g_free(self->namespace);
+            self->namespace = g_value_dup_string(value);
+            break;
+        default:
+            G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
+            break;
+    }
+}
+
+static void astal_river_layout_get_property(GObject* object, guint property_id, GValue* value,
+                                            GParamSpec* pspec) {
+    AstalRiverLayout* self = ASTAL_RIVER_LAYOUT(object);
+
+    switch (property_id) {
+        case ASTAL_RIVER_LAYOUT_PROP_NAMESPACE:
+            g_value_set_string(value, self->namespace);
+            break;
+        default:
+            G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);
+            break;
+    }
+}
+
+static void astal_river_layout_handle_namespace_in_use(void* data, struct river_layout_v3* layout) {
+    struct river_layout_data* layout_data = data;
+    g_signal_emit_by_name(layout_data->layout, "namespace-in-use", layout_data->output);
+}
+
+static void astal_river_layout_handle_layout_demand(void* data, struct river_layout_v3* layout,
+                                                    uint view_count, uint usable_width,
+                                                    uint usable_height, uint tags, uint serial) {
+    struct river_layout_data* layout_data = data;
+    AstalRiverLayoutPrivate* priv = astal_river_layout_get_instance_private(layout_data->layout);
+
+    if (priv->layout_demand_callback == NULL) {
+        return;
+    }
+
+    GList* geometries = NULL;
+    gchar* layout_name = NULL;
+
+    priv->layout_demand_callback(layout_data->layout, layout_data->output, view_count, usable_width,
+                                 usable_height, &layout_name, &geometries,
+                                 priv->layout_demand_user_data);
+
+    for (GList* l = geometries; l != NULL; l = l->next) {
+        AstalRiverGeometry* geometry = (AstalRiverGeometry*)(l->data);
+        river_layout_v3_push_view_dimensions(layout_data->river_layout, geometry->x, geometry->y,
+                                             geometry->width, geometry->height, serial);
+    }
+
+    river_layout_v3_commit(layout_data->river_layout, layout_name, serial);
+
+    g_list_free_full(geometries, (GDestroyNotify)astal_river_geometry_free);
+    g_free(layout_name);
+}
+
+static void noop() {}
+
+static const struct river_layout_v3_listener river_layout_listener = {
+    .namespace_in_use = astal_river_layout_handle_namespace_in_use,
+    .layout_demand = astal_river_layout_handle_layout_demand,
+    .user_command = noop,
+    .user_command_tags = noop};
+
+void astal_river_layout_on_output_added(AstalRiverLayout* self, gchar* output_name) {
+    AstalRiverLayoutPrivate* priv = astal_river_layout_get_instance_private(self);
+    struct river_layout_data* data = g_new0(struct river_layout_data, 1);
+    AstalRiverOutput* output = astal_river_river_get_output(priv->river, output_name);
+    if (output == NULL) return;
+
+    data->layout = self;
+    data->output = output;
+
+    data->river_layout = river_layout_manager_v3_get_layout(
+        priv->layout_manager, astal_river_output_get_wl_output(output), self->namespace);
+    river_layout_v3_add_listener(data->river_layout, &river_layout_listener, data);
+
+    g_hash_table_insert(priv->layouts, g_strdup(output_name), data);
+}
+
+void astal_river_layout_on_output_removed(AstalRiverLayout* self, gchar* output_name) {
+    AstalRiverLayoutPrivate* priv = astal_river_layout_get_instance_private(self);
+    g_hash_table_remove(priv->layouts, output_name);
+}
+
+AstalRiverLayout* astal_river_layout_new(AstalRiverRiver* river,
+                                         struct river_layout_manager_v3* layout_manager,
+                                         struct wl_display* wl_display, const gchar* namespace) {
+    AstalRiverLayout* self = g_object_new(ASTAL_RIVER_TYPE_LAYOUT, "namespace", namespace, NULL);
+    AstalRiverLayoutPrivate* priv = astal_river_layout_get_instance_private(self);
+
+    priv->river = g_object_ref(river);
+    priv->layout_manager = layout_manager;
+    priv->wl_display = wl_display;
+    priv->layouts = g_hash_table_new_full(g_str_hash, g_str_equal, g_free,
+                                          (GDestroyNotify)astal_river_layout_data_free);
+
+    g_signal_connect_swapped(priv->river, "output-added",
+                             G_CALLBACK(astal_river_layout_on_output_added), self);
+    g_signal_connect_swapped(priv->river, "output-removed",
+                             G_CALLBACK(astal_river_layout_on_output_removed), self);
+
+    GList* outputs = astal_river_river_get_outputs(river);
+    for (GList* l = outputs; l != NULL; l = l->next) {
+        AstalRiverOutput* output = ASTAL_RIVER_OUTPUT(l->data);
+        astal_river_layout_on_output_added(self, astal_river_output_get_name(output));
+    }
+
+    return self;
+}
+
+static void astal_river_layout_dispose(GObject* object) {
+    AstalRiverLayout* self = ASTAL_RIVER_LAYOUT(object);
+    AstalRiverLayoutPrivate* priv = astal_river_layout_get_instance_private(self);
+
+    g_hash_table_unref(priv->layouts);
+    g_clear_object(&priv->river);
+}
+
+static void astal_river_layout_finalize(GObject* object) {
+    AstalRiverLayout* self = ASTAL_RIVER_LAYOUT(object);
+    AstalRiverLayoutPrivate* priv = astal_river_layout_get_instance_private(self);
+
+    wl_display_roundtrip(priv->wl_display);
+
+    g_free(self->namespace);
+
+    G_OBJECT_CLASS(astal_river_layout_parent_class)->finalize(object);
+}
+
+static void astal_river_layout_init(AstalRiverLayout* self) {}
+
+static void astal_river_layout_class_init(AstalRiverLayoutClass* class) {
+    GObjectClass* object_class = G_OBJECT_CLASS(class);
+    object_class->get_property = astal_river_layout_get_property;
+    object_class->set_property = astal_river_layout_set_property;
+    object_class->dispose = astal_river_layout_dispose;
+    object_class->finalize = astal_river_layout_finalize;
+    /**
+     * AstalRiverLayout:namespace:
+     *
+     * The namespace of this layout
+     */
+    astal_river_layout_properties[ASTAL_RIVER_LAYOUT_PROP_NAMESPACE] =
+        g_param_spec_string("namespace", "namespace", "the namespace of this layout", NULL,
+                            G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY);
+
+    g_object_class_install_properties(object_class, ASTAL_RIVER_LAYOUT_N_PROPERTIES,
+                                      astal_river_layout_properties);
+
+    /**
+     * AstalRiverLayout::namespace-in-use:
+     * @self: the AstalRiverLayout object
+     *
+     * Emitted when the namespace of this layout is already in use on an output.
+     */
+    astal_river_layout_signals[ASTAL_RIVER_LAYOUT_SIGNAL_NAMESPACE_IN_USE] =
+        g_signal_new("namespace-in-use", ASTAL_RIVER_TYPE_LAYOUT, G_SIGNAL_RUN_LAST, 0, NULL, NULL,
+                     NULL, G_TYPE_NONE, 1, ASTAL_RIVER_TYPE_OUTPUT);
+}

--- a/lib/river/src/river-layout.c
+++ b/lib/river/src/river-layout.c
@@ -306,6 +306,7 @@ static void astal_river_layout_class_init(AstalRiverLayoutClass* class) {
     /**
      * AstalRiverLayout::namespace-in-use:
      * @self: the AstalRiverLayout object
+     * @output: the AstalRiverOutput object that is using the namespace
      *
      * Emitted when the namespace of this layout is already in use on an output.
      */

--- a/lib/river/src/river-layout.c
+++ b/lib/river/src/river-layout.c
@@ -105,7 +105,10 @@ void astal_river_layout_data_free(struct river_layout_data* data) {
  *
  * Returns: (transfer none) (nullable): the namespace of the layout
  */
-const gchar* astal_river_layout_get_namespace(AstalRiverLayout* self) { return self->namespace; }
+const gchar* astal_river_layout_get_namespace(AstalRiverLayout* self) {
+    g_return_val_if_fail(ASTAL_RIVER_IS_LAYOUT(self), NULL);
+    return self->namespace;
+}
 
 /**
  * astal_river_layout_set_layout_demand_callback
@@ -120,6 +123,8 @@ void astal_river_layout_set_layout_demand_callback(AstalRiverLayout* self,
                                                    AstalRiverLayoutDemandCallback callback,
                                                    gpointer user_data,
                                                    GDestroyNotify destroy_notify) {
+    g_return_if_fail(ASTAL_RIVER_IS_LAYOUT(self));
+
     AstalRiverLayoutPrivate* priv = astal_river_layout_get_instance_private(self);
     if (priv->layout_demand_destroy) {
         priv->layout_demand_destroy(priv->layout_demand_user_data);

--- a/lib/river/src/river-layout.c
+++ b/lib/river/src/river-layout.c
@@ -179,6 +179,15 @@ static void astal_river_layout_handle_layout_demand(void* data, struct river_lay
                                  usable_height, &layout_name, &geometries,
                                  priv->layout_demand_user_data);
 
+    if (g_list_length(geometries) != view_count) {
+        g_critical("Invalid layout demand result: received %u geometries but expected %u.",
+                   g_list_length(geometries), view_count);
+        goto exit;
+    }
+    if (layout_name == NULL) {
+        g_critical("Invalid layout demand result: received NULL layout name.");
+        goto exit;
+    }
     for (GList* l = geometries; l != NULL; l = l->next) {
         AstalRiverGeometry* geometry = (AstalRiverGeometry*)(l->data);
         river_layout_v3_push_view_dimensions(layout_data->river_layout, geometry->x, geometry->y,
@@ -187,6 +196,7 @@ static void astal_river_layout_handle_layout_demand(void* data, struct river_lay
 
     river_layout_v3_commit(layout_data->river_layout, layout_name, serial);
 
+exit:
     g_list_free_full(geometries, (GDestroyNotify)astal_river_geometry_free);
     g_free(layout_name);
 }

--- a/lib/river/src/river-layout.c
+++ b/lib/river/src/river-layout.c
@@ -66,6 +66,7 @@ typedef enum {
 
 typedef enum {
     ASTAL_RIVER_LAYOUT_SIGNAL_NAMESPACE_IN_USE,
+    ASTAL_RIVER_LAYOUT_SIGNAL_USER_COMMAND,
     ASTAL_RIVER_LAYOUT_N_SIGNALS
 } AstalRiverLayoutSignals;
 
@@ -201,12 +202,19 @@ exit:
     g_free(layout_name);
 }
 
+static void astal_river_layout_handle_user_command(void* data, struct river_layout_v3* layout,
+                                                   const char* command) {
+    struct river_layout_data* layout_data = data;
+
+    g_signal_emit_by_name(layout_data->layout, "user-command", command, layout_data->output);
+}
+
 static void noop() {}
 
 static const struct river_layout_v3_listener river_layout_listener = {
     .namespace_in_use = astal_river_layout_handle_namespace_in_use,
     .layout_demand = astal_river_layout_handle_layout_demand,
-    .user_command = noop,
+    .user_command = astal_river_layout_handle_user_command,
     .user_command_tags = noop};
 
 void astal_river_layout_on_output_added(AstalRiverLayout* self, gchar* output_name) {
@@ -304,4 +312,16 @@ static void astal_river_layout_class_init(AstalRiverLayoutClass* class) {
     astal_river_layout_signals[ASTAL_RIVER_LAYOUT_SIGNAL_NAMESPACE_IN_USE] =
         g_signal_new("namespace-in-use", ASTAL_RIVER_TYPE_LAYOUT, G_SIGNAL_RUN_LAST, 0, NULL, NULL,
                      NULL, G_TYPE_NONE, 1, ASTAL_RIVER_TYPE_OUTPUT);
+
+    /**
+     * AstalRiverLayout::user-command:
+     * @self: the AstalRiverLayout object
+     * @command: the command send by the user
+     * @output: the currently focused output
+     *
+     * Emitted when a user command is requested for this layout.
+     */
+    astal_river_layout_signals[ASTAL_RIVER_LAYOUT_SIGNAL_USER_COMMAND] =
+        g_signal_new("user_command", ASTAL_RIVER_TYPE_LAYOUT, G_SIGNAL_RUN_LAST, 0, NULL, NULL,
+                     NULL, G_TYPE_NONE, 2, G_TYPE_STRING, ASTAL_RIVER_TYPE_OUTPUT);
 }

--- a/lib/river/src/river-output.c
+++ b/lib/river/src/river-output.c
@@ -2,7 +2,7 @@
 #include <stdint.h>
 #include <wayland-client-protocol.h>
 
-#include "astal-river.h.in"
+#include "astal-river.h"
 #include "glib-object.h"
 #include "glib.h"
 #include "river-private.h"

--- a/lib/river/src/river-output.c
+++ b/lib/river/src/river-output.c
@@ -106,7 +106,10 @@ static GParamSpec* astal_river_output_properties[ASTAL_RIVER_OUTPUT_N_PROPERTIES
  *
  * Returns: the id of the underlying wl_output object
  */
-guint astal_river_output_get_id(AstalRiverOutput* self) { return self->id; }
+guint astal_river_output_get_id(AstalRiverOutput* self) {
+    g_return_val_if_fail(ASTAL_RIVER_IS_OUTPUT(self), 0);
+    return self->id;
+}
 
 /**
  * astal_river_output_get_name
@@ -116,7 +119,10 @@ guint astal_river_output_get_id(AstalRiverOutput* self) { return self->id; }
  *
  * Returns: (transfer none) (nullable): the name of the output
  */
-gchar* astal_river_output_get_name(AstalRiverOutput* self) { return self->name; }
+gchar* astal_river_output_get_name(AstalRiverOutput* self) {
+    g_return_val_if_fail(ASTAL_RIVER_IS_OUTPUT(self), NULL);
+    return self->name;
+}
 
 /**
  * astal_river_output_get_layout_name
@@ -126,7 +132,10 @@ gchar* astal_river_output_get_name(AstalRiverOutput* self) { return self->name; 
  *
  * Returns: (transfer none) (nullable): the currently used layout name of the output
  */
-gchar* astal_river_output_get_layout_name(AstalRiverOutput* self) { return self->layout_name; }
+gchar* astal_river_output_get_layout_name(AstalRiverOutput* self) {
+    g_return_val_if_fail(ASTAL_RIVER_IS_OUTPUT(self), NULL);
+    return self->layout_name;
+}
 
 /**
  * astal_river_output_get_focused_view
@@ -136,9 +145,14 @@ gchar* astal_river_output_get_layout_name(AstalRiverOutput* self) { return self-
  *
  * Returns: (transfer none) (nullable): the focused view on the output
  */
-gchar* astal_river_output_get_focused_view(AstalRiverOutput* self) { return self->focused_view; }
+gchar* astal_river_output_get_focused_view(AstalRiverOutput* self) {
+    g_return_val_if_fail(ASTAL_RIVER_IS_OUTPUT(self), NULL);
+    return self->focused_view;
+}
 
 void astal_river_output_set_focused_view(AstalRiverOutput* self, const gchar* focused_view) {
+    g_return_if_fail(ASTAL_RIVER_IS_OUTPUT(self));
+
     g_free(self->focused_view);
     self->focused_view = g_strdup(focused_view);
     g_object_notify(G_OBJECT(self), "focused-view");
@@ -154,6 +168,8 @@ void astal_river_output_set_focused_view(AstalRiverOutput* self, const gchar* fo
  *
  */
 void astal_river_output_set_focused_tags(AstalRiverOutput* self, guint tags) {
+    g_return_if_fail(ASTAL_RIVER_IS_OUTPUT(self));
+
     AstalRiverOutputPrivate* priv = astal_river_output_get_instance_private(self);
     gchar* tagstring = g_strdup_printf("%i", tags);
 
@@ -172,7 +188,10 @@ void astal_river_output_set_focused_tags(AstalRiverOutput* self, guint tags) {
  *
  * Returns: the focused tags of the output
  */
-guint astal_river_output_get_focused_tags(AstalRiverOutput* self) { return self->focused_tags; }
+guint astal_river_output_get_focused_tags(AstalRiverOutput* self) {
+    g_return_val_if_fail(ASTAL_RIVER_IS_OUTPUT(self), 0);
+    return self->focused_tags;
+}
 
 /**
  * astal_river_output_get_urgent_tags
@@ -182,7 +201,10 @@ guint astal_river_output_get_focused_tags(AstalRiverOutput* self) { return self-
  *
  * Returns: the urgent tags of the output
  */
-guint astal_river_output_get_urgent_tags(AstalRiverOutput* self) { return self->urgent_tags; }
+guint astal_river_output_get_urgent_tags(AstalRiverOutput* self) {
+    g_return_val_if_fail(ASTAL_RIVER_IS_OUTPUT(self), 0);
+    return self->urgent_tags;
+}
 
 /**
  * astal_river_output_get_occupied_tags
@@ -192,15 +214,21 @@ guint astal_river_output_get_urgent_tags(AstalRiverOutput* self) { return self->
  *
  * Returns: the occupied tags of the output
  */
-guint astal_river_output_get_occupied_tags(AstalRiverOutput* self) { return self->occupied_tags; }
+guint astal_river_output_get_occupied_tags(AstalRiverOutput* self) {
+    g_return_val_if_fail(ASTAL_RIVER_IS_OUTPUT(self), 0);
+    return self->occupied_tags;
+}
 
 /**
  * astal_river_output_get_description
  * @self: the AstalRiverOutput object
  *
  * the description of the output
+ *
+ * Returns: (transfer none) (nullable):
  */
 const gchar* astal_river_output_get_description(AstalRiverOutput* self) {
+    g_return_val_if_fail(ASTAL_RIVER_IS_OUTPUT(self), NULL);
     return self->description;
 }
 
@@ -209,16 +237,26 @@ const gchar* astal_river_output_get_description(AstalRiverOutput* self) {
  * @self: the AstalRiverOutput object
  *
  * the make of the output
+ *
+ * Returns: (transfer none) (nullable): 
  */
-const gchar* astal_river_output_get_make(AstalRiverOutput* self) { return self->make; }
+const gchar* astal_river_output_get_make(AstalRiverOutput* self) {
+    g_return_val_if_fail(ASTAL_RIVER_IS_OUTPUT(self), NULL);
+    return self->make;
+}
 
 /**
  * astal_river_output_get_model
  * @self: the AstalRiverOutput object
  *
  * the model of the output
+ *
+ * Returns: (transfer none) (nullable):
  */
-const gchar* astal_river_output_get_model(AstalRiverOutput* self) { return self->model; }
+const gchar* astal_river_output_get_model(AstalRiverOutput* self) {
+    g_return_val_if_fail(ASTAL_RIVER_IS_OUTPUT(self), NULL);
+    return self->model;
+}
 
 /**
  * astal_river_output_get_x
@@ -226,7 +264,10 @@ const gchar* astal_river_output_get_model(AstalRiverOutput* self) { return self-
  *
  * the x coordinate of the outputs position
  */
-gint astal_river_output_get_x(AstalRiverOutput* self) { return self->x; }
+gint astal_river_output_get_x(AstalRiverOutput* self) {
+    g_return_val_if_fail(ASTAL_RIVER_IS_OUTPUT(self), 0);
+    return self->x;
+}
 
 /**
  * astal_river_output_get_y
@@ -234,7 +275,10 @@ gint astal_river_output_get_x(AstalRiverOutput* self) { return self->x; }
  *
  * the y coordinate of the outputs position
  */
-gint astal_river_output_get_y(AstalRiverOutput* self) { return self->y; }
+gint astal_river_output_get_y(AstalRiverOutput* self) {
+    g_return_val_if_fail(ASTAL_RIVER_IS_OUTPUT(self), 0);
+    return self->y;
+}
 
 /**
  * astal_river_output_get_width
@@ -242,7 +286,10 @@ gint astal_river_output_get_y(AstalRiverOutput* self) { return self->y; }
  *
  * the width of the output
  */
-gint astal_river_output_get_width(AstalRiverOutput* self) { return self->width; }
+gint astal_river_output_get_width(AstalRiverOutput* self) {
+    g_return_val_if_fail(ASTAL_RIVER_IS_OUTPUT(self), 0);
+    return self->width;
+}
 
 /**
  * astal_river_output_get_height
@@ -250,7 +297,10 @@ gint astal_river_output_get_width(AstalRiverOutput* self) { return self->width; 
  *
  * the height of the output
  */
-gint astal_river_output_get_height(AstalRiverOutput* self) { return self->height; }
+gint astal_river_output_get_height(AstalRiverOutput* self) {
+    g_return_val_if_fail(ASTAL_RIVER_IS_OUTPUT(self), 0);
+    return self->height;
+}
 
 /**
  * astal_river_output_get_physical_width
@@ -258,7 +308,10 @@ gint astal_river_output_get_height(AstalRiverOutput* self) { return self->height
  *
  * the physical width of the output
  */
-gint astal_river_output_get_physical_width(AstalRiverOutput* self) { return self->physical_width; }
+gint astal_river_output_get_physical_width(AstalRiverOutput* self) {
+    g_return_val_if_fail(ASTAL_RIVER_IS_OUTPUT(self), 0);
+    return self->physical_width;
+}
 
 /**
  * astal_river_output_get_physical_height
@@ -267,6 +320,7 @@ gint astal_river_output_get_physical_width(AstalRiverOutput* self) { return self
  * the physical height of the output
  */
 gint astal_river_output_get_physical_height(AstalRiverOutput* self) {
+    g_return_val_if_fail(ASTAL_RIVER_IS_OUTPUT(self), 0);
     return self->physical_height;
 }
 
@@ -276,7 +330,10 @@ gint astal_river_output_get_physical_height(AstalRiverOutput* self) {
  *
  * the scale factor of the output
  */
-gint astal_river_output_get_scale_factor(AstalRiverOutput* self) { return self->scale_factor; }
+gint astal_river_output_get_scale_factor(AstalRiverOutput* self) {
+    g_return_val_if_fail(ASTAL_RIVER_IS_OUTPUT(self), 1);
+    return self->scale_factor;
+}
 
 /**
  * astal_river_output_get_refresh_rate
@@ -284,7 +341,10 @@ gint astal_river_output_get_scale_factor(AstalRiverOutput* self) { return self->
  *
  * the refresh rate of the output
  */
-gdouble astal_river_output_get_refresh_rate(AstalRiverOutput* self) { return self->refresh_rate; }
+gdouble astal_river_output_get_refresh_rate(AstalRiverOutput* self) {
+    g_return_val_if_fail(ASTAL_RIVER_IS_OUTPUT(self), 0);
+    return self->refresh_rate;
+}
 
 /**
  * astal_river_output_get_transform
@@ -293,10 +353,12 @@ gdouble astal_river_output_get_refresh_rate(AstalRiverOutput* self) { return sel
  * the transform of the output
  */
 AstalRiverTransform astal_river_output_get_transform(AstalRiverOutput* self) {
+    g_return_val_if_fail(ASTAL_RIVER_IS_OUTPUT(self), 0);
     return self->transform;
 }
 
 struct wl_output* astal_river_output_get_wl_output(AstalRiverOutput* self) {
+    g_return_val_if_fail(ASTAL_RIVER_IS_OUTPUT(self), NULL);
     AstalRiverOutputPrivate* priv = astal_river_output_get_instance_private(self);
     return priv->wl_output;
 }

--- a/lib/river/src/river.c
+++ b/lib/river/src/river.c
@@ -184,7 +184,7 @@ static void astal_river_river_get_property(GObject* object, guint property_id, G
  * @self: the AstalRiverRiver object
  * @namespace: the namespace of the layout
  *
- * creates a new AstalRiverLayout object for this river instance.
+ * creates a new [class@AstalRiver.Layout] object for this river instance.
  *
  * Returns: (transfer full): a newly created AstalRiverLayout object
  */

--- a/lib/river/src/river.c
+++ b/lib/river/src/river.c
@@ -67,6 +67,8 @@ static void reemit_changed(AstalRiverOutput* output, AstalRiverRiver* self) {
 }
 
 static AstalRiverOutput* find_output_by_id(AstalRiverRiver* self, uint32_t id) {
+    g_return_val_if_fail(ASTAL_RIVER_IS_RIVER(self), NULL);
+
     GList* output = self->outputs;
     while (output != NULL) {
         AstalRiverOutput* river_output = output->data;
@@ -77,6 +79,8 @@ static AstalRiverOutput* find_output_by_id(AstalRiverRiver* self, uint32_t id) {
 }
 
 static AstalRiverOutput* find_output_by_output(AstalRiverRiver* self, struct wl_output* wl_output) {
+    g_return_val_if_fail(ASTAL_RIVER_IS_RIVER(self), NULL);
+
     GList* output = self->outputs;
     while (output != NULL) {
         AstalRiverOutput* river_output = output->data;
@@ -87,6 +91,8 @@ static AstalRiverOutput* find_output_by_output(AstalRiverRiver* self, struct wl_
 }
 
 static AstalRiverOutput* find_output_by_name(AstalRiverRiver* self, gchar* name) {
+    g_return_val_if_fail(ASTAL_RIVER_IS_RIVER(self), NULL);
+
     GList* output = self->outputs;
     while (output != NULL) {
         AstalRiverOutput* river_output = output->data;
@@ -111,7 +117,10 @@ static AstalRiverOutput* find_output_by_name(AstalRiverRiver* self, gchar* name)
  * Returns: (transfer none) (element-type AstalRiver.Output): a list of all outputs
  *
  */
-GList* astal_river_river_get_outputs(AstalRiverRiver* self) { return self->outputs; }
+GList* astal_river_river_get_outputs(AstalRiverRiver* self) {
+    g_return_val_if_fail(ASTAL_RIVER_IS_RIVER(self), NULL);
+    return self->outputs;
+}
 
 /**
  * astal_river_river_get_output
@@ -123,6 +132,7 @@ GList* astal_river_river_get_outputs(AstalRiverRiver* self) { return self->outpu
  * Returns: (transfer none) (nullable): the output with the given name or null
  */
 AstalRiverOutput* astal_river_river_get_output(AstalRiverRiver* self, gchar* name) {
+    g_return_val_if_fail(ASTAL_RIVER_IS_RIVER(self), NULL);
     return find_output_by_name(self, name);
 }
 
@@ -134,7 +144,10 @@ AstalRiverOutput* astal_river_river_get_output(AstalRiverRiver* self, gchar* nam
  *
  * Returns: (transfer none) (nullable): the currently focused view
  */
-gchar* astal_river_river_get_focused_view(AstalRiverRiver* self) { return self->focused_view; }
+gchar* astal_river_river_get_focused_view(AstalRiverRiver* self) {
+    g_return_val_if_fail(ASTAL_RIVER_IS_RIVER(self), NULL);
+    return self->focused_view;
+}
 
 /**
  * astal_river_river_get_focused_output
@@ -144,7 +157,10 @@ gchar* astal_river_river_get_focused_view(AstalRiverRiver* self) { return self->
  *
  * Returns: (transfer none) (nullable): the name of the currently focused output
  */
-gchar* astal_river_river_get_focused_output(AstalRiverRiver* self) { return self->focused_output; }
+gchar* astal_river_river_get_focused_output(AstalRiverRiver* self) {
+    g_return_val_if_fail(ASTAL_RIVER_IS_RIVER(self), NULL);
+    return self->focused_output;
+}
 
 /**
  * astal_river_river_get_mode
@@ -154,7 +170,10 @@ gchar* astal_river_river_get_focused_output(AstalRiverRiver* self) { return self
  *
  * Returns: (transfer none) (nullable): the currently active mode
  */
-gchar* astal_river_river_get_mode(AstalRiverRiver* self) { return self->mode; }
+gchar* astal_river_river_get_mode(AstalRiverRiver* self) {
+    g_return_val_if_fail(ASTAL_RIVER_IS_RIVER(self), NULL);
+    return self->mode;
+}
 
 static void astal_river_river_get_property(GObject* object, guint property_id, GValue* value,
                                            GParamSpec* pspec) {
@@ -189,6 +208,8 @@ static void astal_river_river_get_property(GObject* object, guint property_id, G
  * Returns: (transfer full): a newly created AstalRiverLayout object
  */
 AstalRiverLayout* astal_river_river_new_layout(AstalRiverRiver* self, const gchar* namespace) {
+    g_return_val_if_fail(ASTAL_RIVER_IS_RIVER(self), NULL);
+
     AstalRiverRiverPrivate* priv = astal_river_river_get_instance_private(self);
     return astal_river_layout_new(self, priv->river_layout_manager, priv->display, namespace);
 }
@@ -234,7 +255,7 @@ static void river_seat_status_handle_focused_view(void* data,
     g_free(self->focused_view);
     self->focused_view = g_strdup(focused_view);
     AstalRiverOutput* output = find_output_by_name(self, self->focused_output);
-    astal_river_output_set_focused_view(output, focused_view);
+    if (output != NULL) astal_river_output_set_focused_view(output, focused_view);
     g_object_notify(G_OBJECT(self), "focused-view");
     g_signal_emit(self, astal_river_river_signals[ASTAL_RIVER_RIVER_SIGNAL_CHANGED], 0);
 }
@@ -313,6 +334,8 @@ const struct zriver_command_callback_v1_listener cb_listener = {
  */
 void astal_river_river_run_command_async(AstalRiverRiver* self, gint length, const gchar** cmd,
                                          AstalRiverCommandCallback callback) {
+    g_return_if_fail(ASTAL_RIVER_IS_RIVER(self));
+
     AstalRiverRiverPrivate* priv = astal_river_river_get_instance_private(self);
 
     for (gint i = 0; i < length; ++i) {


### PR DESCRIPTION
Adds support for the River layout protocol which enables clients to propose window layouts. This includes:

- New AstalRiverLayout type for managing layouts
- AstalRiverGeometry type for specifying window geometries
- Implementation of layout demand callback mechanism
