### PR TITLE
fix(hyprland): check if monitor exists before removing

### DIFF
--- a/lib/hyprland/hyprland.vala
+++ b/lib/hyprland/hyprland.vala
@@ -339,11 +339,14 @@ public class Hyprland : Object {
                 yield sync_clients();
                 break;
 
-            case "monitorremoved":
-                var id = get_monitor_by_name(args[1]).id;
-                _monitors.get(id).removed();
-                _monitors.remove(id);
-                monitor_removed(id);
+            case "monitorremovedv2":
+                var argv = args[1].split(",", 2);
+                var monitor = get_monitor(int.parse(argv[0]));
+                if (monitor == null)
+                    break;
+                monitor.removed();
+                _monitors.remove(monitor.id);
+                monitor_removed(monitor.id);
                 notify_property("monitors");
                 break;
 


### PR DESCRIPTION
closes #350

The Hyprland IPC spams monitorremovedv2 when a monitor is removed:

```bash
08:11:44 monitoradded>>grimblastVD
08:11:44 monitoraddedv2>>2,grimblastVD,
...
08:11:45 monitorremoved>>grimblastVD
08:11:45 monitorremovedv2>>2,grimblastVD,
08:11:45 monitorremoved>>grimblastVD
08:11:45 monitorremovedv2>>2,grimblastVD,
08:11:45 monitorremoved>>grimblastVD
08:11:45 monitorremovedv2>>2,grimblastVD,
```

and currently there's no check to make sure the monitor actually exists before trying to remove it, causing an error:

```bash
** (gjs:126146): CRITICAL **: 08:15:51.597: astal_hyprland_monitor_get_id: assertion 'self != NULL' failed
** (gjs:126146): CRITICAL **: 08:15:51.598: astal_hyprland_monitor_get_id: assertion 'self != NULL' failed
(gjs:126146): GLib-GObject-CRITICAL **: 08:15:51.598: invalid (NULL) pointer instance
(gjs:126146): GLib-GObject-CRITICAL **: 08:15:51.598: g_signal_emit_by_name: assertion 'G_TYPE_CHECK_INSTANCE (instance)' failed
```