### PR TITLE
Update cava version to 10.4

### DIFF
--- a/lib/cava/default.nix
+++ b/lib/cava/default.nix
@@ -5,13 +5,13 @@
 }: let
   libcava = pkgs.stdenv.mkDerivation rec {
     pname = "cava";
-    version = "0.10.3";
+    version = "0.10.4";
 
     src = pkgs.fetchFromGitHub {
       owner = "LukashonakV";
       repo = "cava";
-      rev = "0.10.3";
-      hash = "sha256-ZDFbI69ECsUTjbhlw2kHRufZbQMu+FQSMmncCJ5pagg=";
+      rev = "0.10.4";
+      hash = "sha256-9eTDqM+O1tA/3bEfd1apm8LbEcR9CVgELTIspSVPMKM=";
     };
 
     buildInputs = with pkgs; [

--- a/lib/cava/subprojects/cava.wrap
+++ b/lib/cava/subprojects/cava.wrap
@@ -1,7 +1,7 @@
 [wrap-file]
-directory = cava-0.10.3
-source_url = https://github.com/LukashonakV/cava/archive/0.10.3.tar.gz
-source_filename = cava-0.10.3.tar.gz
-source_hash = aab0a4ed3f999e8461ad9de63ef8a77f28b6b2011f7dd0c69ba81819d442f6f9
+directory = cava-0.10.4
+source_url = https://github.com/LukashonakV/cava/archive/0.10.4.tar.gz
+source_filename = cava-0.10.4.tar.gz
+source_hash = 7bc1c1f9535f2bcc5cd2ae8a2434a2e3a05f5670b1c96316df304137ffc65756
 [provide]
 cava = cava_dep


### PR DESCRIPTION
Hey, opening a PR to update the libcava version to 10.4. I was encountering segfaults when trying to run [HyprPanel](https://hyprpanel.com/) after updating libcava to version 10.4 locally. I'm not sure why a minor version upgrade would introduce any issues, but upgrading the libcava version used by Astal to 10.4 as well seemed to have fixed the issue.

Fwiw, this is how the stacktrace looks like before updating the version:
```
                #0  0x00007fa6641805d6 n/a (libc.so.6 + 0x1805d6)
                #1  0x00007fa63801048c audio_raw_init (libcava.so + 0xd48c)
                #2  0x00007fa6380317b0 n/a (libastal-cava.so.0 + 0x27b0)
                #3  0x00007fa6649217ca n/a (libgobject-2.0.so.0 + 0x237ca)
                #4  0x00007fa664922ce7 g_object_new_with_properties (libgobject-2.0.so.0 + 0x24ce7)
                #5  0x00007fa664923d22 g_object_new (libgobject-2.0.so.0 + 0x25d22)
                #6  0x00007fa6380325af astal_cava_cava_get_default (libastal-cava.so.0 + 0x35af)
                #7  0x00007fa6646d9ac6 n/a (libffi.so.8 + 0x7ac6)
                #8  0x00007fa6646d676b n/a (libffi.so.8 + 0x476b)
                #9  0x00007fa6646d906e ffi_call (libffi.so.8 + 0x706e)
                #10 0x00007fa664b78952 n/a (libgjs.so.0 + 0xc5952)
                #11 0x00007fa664b7934f n/a (libgjs.so.0 + 0xc634f)
                #12 0x00007fa663265605 n/a (libmozjs-128.so + 0x1665605)
                #13 0x00007fa6632f8cb9 n/a (libmozjs-128.so + 0x16f8cb9)
                #14 0x00007fa66335466a n/a (libmozjs-128.so + 0x175466a)
                #15 0x00007fa663355a37 n/a (libmozjs-128.so + 0x1755a37)
                #16 0x00002520f7837e95 n/a (n/a + 0x0)
                #17 0x00002520f78a55b5 n/a (n/a + 0x0)
                #18 0x00002520f785fd20 n/a (n/a + 0x0)
                #19 0x00002520f78374e6 n/a (n/a + 0x0)
                #20 0x00007fa66325f7fd n/a (libmozjs-128.so + 0x165f7fd)
                #21 0x00007fa663264df4 n/a (libmozjs-128.so + 0x1664df4)
                #22 0x00007fa6632f8cb9 n/a (libmozjs-128.so + 0x16f8cb9)
                #23 0x00007fa66335466a n/a (libmozjs-128.so + 0x175466a)
                #24 0x00007fa663355a37 n/a (libmozjs-128.so + 0x1755a37)
                #25 0x00002520f7837e95 n/a (n/a + 0x0)
                #26 0x00002520f78a96f3 n/a (n/a + 0x0)
                #27 0x00002520f7840f12 n/a (n/a + 0x0)
                #28 0x00002520f78a91a1 n/a (n/a + 0x0)
                #29 0x00002520f7840de1 n/a (n/a + 0x0)
                #30 0x00002520f78374e6 n/a (n/a + 0x0)
                #31 0x00007fa66325f7fd n/a (libmozjs-128.so + 0x165f7fd)
                #32 0x00007fa663264df4 n/a (libmozjs-128.so + 0x1664df4)
                #33 0x00007fa6632f8cb9 n/a (libmozjs-128.so + 0x16f8cb9)
                #34 0x00007fa6635c048c n/a (libmozjs-128.so + 0x19c048c)
                #35 0x00007fa6636fc81a n/a (libmozjs-128.so + 0x1afc81a)
                #36 0x00002520f783abef n/a (n/a + 0x0)
                #37 0x00002520f78a07a2 n/a (n/a + 0x0)
                #38 0x00002520f78374e6 n/a (n/a + 0x0)
                #39 0x00007fa6632f7d5d n/a (libmozjs-128.so + 0x16f7d5d)
                #40 0x00007fa6635c048c n/a (libmozjs-128.so + 0x19c048c)
                #41 0x00007fa6638cd073 n/a (libmozjs-128.so + 0x1ccd073)
                #42 0x00007fa66336b4a2 n/a (libmozjs-128.so + 0x176b4a2)
                #43 0x00007fa6632f852c n/a (libmozjs-128.so + 0x16f852c)
                #44 0x00007fa66336ad30 _ZN2JS4CallEP9JSContextNS_6HandleINS_5ValueEEES4_RKNS_16HandleVal>
                #45 0x00007fa664bd9bfd n/a (libgjs.so.0 + 0x126bfd)
                #46 0x00007fa664bd9f0d n/a (libgjs.so.0 + 0x126f0d)
                #47 0x00007fa66336a588 _ZN2js7RunJobsEP9JSContext (libmozjs-128.so + 0x176a588)
                #48 0x00007fa664bea1e0 n/a (libgjs.so.0 + 0x1371e0)
                #49 0x00007fa6649bb87d n/a (libglib-2.0.so.0 + 0x5e87d)
                #50 0x00007fa6649bccd7 n/a (libglib-2.0.so.0 + 0x5fcd7)
                #51 0x00007fa6649bcee5 g_main_context_iteration (libglib-2.0.so.0 + 0x5fee5)
                #52 0x00007fa664812b26 g_application_run (libgio-2.0.so.0 + 0xe1b26)
                #53 0x00007fa6646d9ac6 n/a (libffi.so.8 + 0x7ac6)
                #54 0x00007fa6646d676b n/a (libffi.so.8 + 0x476b)
                #55 0x00007fa6646d906e ffi_call (libffi.so.8 + 0x706e)
                #56 0x00007fa664b78952 n/a (libgjs.so.0 + 0xc5952)
                #57 0x00007fa664b7934f n/a (libgjs.so.0 + 0xc634f)
                #58 0x00007fa6632782cd n/a (libmozjs-128.so + 0x16782cd)
                #59 0x00007fa6633eb9a3 n/a (libmozjs-128.so + 0x17eb9a3)
                #60 0x00007fa66326c38f n/a (libmozjs-128.so + 0x166c38f)
                #61 0x00007fa6632f8cb9 n/a (libmozjs-128.so + 0x16f8cb9)
                #62 0x00007fa66336ad30 _ZN2JS4CallEP9JSContextNS_6HandleINS_5ValueEEES4_RKNS_16HandleVal>
                #63 0x00007fa664bd5f44 n/a (libgjs.so.0 + 0x122f44)
```