### PR TITLE
feat(network): add access-point-added/-removed signals to wifi

### DIFF
--- a/lib/network/src/accesspoint.vala
+++ b/lib/network/src/accesspoint.vala
@@ -1,6 +1,6 @@
 public class AstalNetwork.AccessPoint : Object {
     private Wifi wifi;
-    private NM.AccessPoint ap;
+    public NM.AccessPoint ap;
 
     public uint bandwidth { get { return ap.bandwidth; } }
     public string bssid { owned get { return ap.bssid; } }

--- a/lib/network/src/wifi.vala
+++ b/lib/network/src/wifi.vala
@@ -41,22 +41,31 @@ public class AstalNetwork.Wifi : Object {
     public bool is_hotspot { get; private set; }
     public bool scanning { get; private set; }
 
+    public signal void access_point_added(AccessPoint ap) ;
+    public signal void access_point_removed(AccessPoint ap) ;
+
     internal Wifi(NM.DeviceWifi device) {
         this.device = device;
 
         foreach (var ap in device.access_points) {
-            _access_points.set(ap.bssid, new AccessPoint(this, ap));
+            var new_ap = new AccessPoint(this, ap);
+            _access_points.set(ap.bssid, new_ap);
+            access_point_added(new_ap);
         }
 
         device.access_point_added.connect((access_point) => {
             var ap = (NM.AccessPoint)access_point;
-            _access_points.set(ap.bssid, new AccessPoint(this, ap));
+            var new_ap = new AccessPoint(this, ap);
+            _access_points.set(ap.bssid, new_ap);
+            access_point_added(new_ap);
             notify_property("access-points");
         });
 
         device.access_point_removed.connect((access_point) => {
             var ap = (NM.AccessPoint)access_point;
+            var rem_ap = _access_points.get(ap.bssid);
             _access_points.remove(ap.bssid);
+            access_point_removed(rem_ap);
             notify_property("access-points");
         });
 


### PR DESCRIPTION
This PR adds `access-point-added` and `access-point-removed` signals to the AstalNetwork.Wifi object, which allows adding/removing eg items from a Gtk.ListBox without removing and readding all of them or manually diffing the list, which would be needed in languages other than js with gnim.

Also makes the `AstalNetwork.AccessPoint.ap` property public to give the user more possibilities, eg for creating new connections, which aren't a simple password. Otherwise you would need to use libnm directly to get the Nm.AccessPoint and the match that to the AstalNetwork.AccessPoint.