### PR TITLE
fix(nix): `pkgs.system` -> `pkgs.stdenv.hostPlatform.system`

### DIFF
--- a/docs/default.nix
+++ b/docs/default.nix
@@ -3,7 +3,7 @@
   pkgs,
 }: let
   inherit (builtins) removeAttrs concatStringsSep map attrValues;
-  packages = attrValues (removeAttrs self.packages.${pkgs.system} ["default" "docs"]);
+  packages = attrValues (removeAttrs self.packages.${pkgs.stdenv.hostPlatform.system} ["default" "docs"]);
 
   cp = pkg: ''
     doc="${pkg.doc}/share/doc"

--- a/lang/gjs/default.nix
+++ b/lang/gjs/default.nix
@@ -10,7 +10,7 @@ pkgs.stdenvNoCC.mkDerivation {
     pkgs.meson
     pkgs.ninja
     pkgs.pkg-config
-    self.packages.${pkgs.system}.io
-    self.packages.${pkgs.system}.astal3
+    self.packages.${pkgs.stdenv.hostPlatform.system}.io
+    self.packages.${pkgs.stdenv.hostPlatform.system}.astal3
   ];
 }

--- a/lib/astal/gtk3/default.nix
+++ b/lib/astal/gtk3/default.nix
@@ -7,7 +7,7 @@ mkAstalPkg {
   pname = "astal3";
   src = ./.;
   packages = [
-    self.packages.${pkgs.system}.io
+    self.packages.${pkgs.stdenv.hostPlatform.system}.io
     pkgs.gtk3
     pkgs.gtk-layer-shell
   ];

--- a/lib/astal/gtk4/default.nix
+++ b/lib/astal/gtk4/default.nix
@@ -7,7 +7,7 @@ mkAstalPkg {
   pname = "astal4";
   src = ./.;
   packages = [
-    self.packages.${pkgs.system}.io
+    self.packages.${pkgs.stdenv.hostPlatform.system}.io
     pkgs.gtk4
     pkgs.gtk4-layer-shell
   ];

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -69,7 +69,7 @@ in {
       buildInputs
       ++ dev
       ++ builtins.attrValues (
-        builtins.removeAttrs self.packages.${pkgs.system} ["docs"]
+        builtins.removeAttrs self.packages.${pkgs.stdenv.hostPlatform.system} ["docs"]
       );
   };
 }


### PR DESCRIPTION
nixpkgs seems to be deprecating `pkgs.system` in favor of `pkgs.stdenv.hostPlatform.system`.

Building my config outputs this warning:
```shell
evaluation warning: 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'
```

Thank you for this project :)