### PR TITLE
fix(mpris): skip caching base64 cover arts

### DIFF
--- a/lib/mpris/src/player.vala
+++ b/lib/mpris/src/player.vala
@@ -680,6 +680,10 @@ public class AstalMpris.Player : Object {
             return;
         }
 
+        if (art_url.has_prefix("data:")) {
+            return;
+        }
+
         var file = File.new_for_uri(art_url);
         if (file.get_path() != null) {
             cover_art = file.get_path();


### PR DESCRIPTION
This fixes thousands of lines of base64 output splattering all over your terminal. 
<img width="1606" height="514" alt="image" src="https://github.com/user-attachments/assets/b5b40ff1-25f4-4444-888e-6fe97fa29523" />
