### PR TITLE
feature(hyprland): added full support of groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ result-dev
 .cache/
 test.sh
 tmp/
+.vscode/

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1761672384,
-        "narHash": "sha256-o9KF3DJL7g7iYMZq9SWgfS1BFlNbsm6xplRjVlOCkXI=",
+        "lastModified": 1766070988,
+        "narHash": "sha256-G/WVghka6c4bAzMhTwT2vjLccg/awmHkdKSd2JrycLc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "08dacfca559e1d7da38f3cf05f1f45ee9bfd213c",
+        "rev": "c6245e83d836d0433170a16eb185cefe0572f8b8",
         "type": "github"
       },
       "original": {

--- a/lib/hyprland/meson.build
+++ b/lib/hyprland/meson.build
@@ -49,6 +49,7 @@ sources = [config] + files(
   'src/monitor.vala',
   'src/structs.vala',
   'src/workspace.vala',
+  'src/group.vala',
 )
 
 if get_option('lib')
@@ -80,6 +81,7 @@ if get_option('lib')
         'Hyprland.monitors',
         'Hyprland.workspaces',
         'Hyprland.clients',
+        'Hyprland.groups',
       ),
       sources,
     ],

--- a/lib/hyprland/src/client.vala
+++ b/lib/hyprland/src/client.vala
@@ -25,7 +25,8 @@ public class Client : Object {
 
     // TODO: public Group[] grouped { get; private set; }
     // TODO: public Tag[] tags { get; private set; }
-    public unowned List<string> grouped { get; private set; }
+    public List<weak string> _grouped = new List<weak string>();
+    public List<weak string> grouped { owned get { return _grouped.copy(); } }
     public string swallowing { get; private set; }
     public int focus_history_id { get; private set; }
 
@@ -52,9 +53,8 @@ public class Client : Object {
         fullscreen = (Fullscreen)obj.get_int_member("fullscreen");
         fullscreen_client = (Fullscreen)obj.get_int_member("fullscreenClient");
 
-        grouped = new List<string>();
         foreach (var addr in obj.get_array_member("grouped").get_elements())
-            grouped.append(addr.get_string().replace("0x", ""));
+            _grouped.append(addr.get_string().replace("0x", ""));
 
         workspace = hyprland.get_workspace((int)obj.get_object_member("workspace").get_int_member("id"));
         monitor = hyprland.get_monitor((int)obj.get_int_member("monitor"));

--- a/lib/hyprland/src/client.vala
+++ b/lib/hyprland/src/client.vala
@@ -10,6 +10,7 @@ public class Client : Object {
     public int y { get; private set; }
     public int width { get; private set; }
     public int height { get; private set; }
+    public Group group { get; private set; }
     public Workspace workspace { get; private set; }
     public bool floating { get; private set; }
     public Monitor monitor { get; private set; }
@@ -23,9 +24,9 @@ public class Client : Object {
     public Fullscreen fullscreen { get; private set; }
     public Fullscreen fullscreen_client { get; private set; }
 
-    // TODO: public Group[] grouped { get; private set; }
     // TODO: public Tag[] tags { get; private set; }
-    public string[] grouped { get; private set; }
+    private List<string> _grouped = new List<string>();
+    public List<string> grouped { get { return _grouped; } }
     public string swallowing { get; private set; }
     public int focus_history_id { get; private set; }
 
@@ -51,16 +52,12 @@ public class Client : Object {
         height = (int)obj.get_array_member("size").get_int_element(1);
         fullscreen = (Fullscreen)obj.get_int_member("fullscreen");
         fullscreen_client = (Fullscreen)obj.get_int_member("fullscreenClient");
-        
-        string[] _grouped = {};
-        foreach (unowned Json.Node node in obj.get_array_member("grouped").get_elements()) {
-            unowned string raw_val = node.get_string();
-            if (raw_val != null) {
-                _grouped += raw_val.replace("0x", "");
-            }
-        }
-        grouped = _grouped;
 
+        foreach (var addr in obj.get_array_member("grouped").get_elements()) {
+            _grouped.append(addr.get_string().replace("0x", ""));
+        }
+
+        group = hyprland.get_group_from_addresses(_grouped);
         workspace = hyprland.get_workspace((int)obj.get_object_member("workspace").get_int_member("id"));
         monitor = hyprland.get_monitor((int)obj.get_int_member("monitor"));
     }
@@ -81,13 +78,5 @@ public class Client : Object {
     public void toggle_floating() {
         Hyprland.get_default().dispatch("togglefloating", @"address:0x$address");
     }
-}
-
-[Flags]
-public enum Fullscreen {
-    CURRENT = -1,
-    NONE = 0,
-    MAXIMIZED = 1,
-    FULLSCREEN = 2,
 }
 }

--- a/lib/hyprland/src/client.vala
+++ b/lib/hyprland/src/client.vala
@@ -25,7 +25,7 @@ public class Client : Object {
 
     // TODO: public Group[] grouped { get; private set; }
     // TODO: public Tag[] tags { get; private set; }
-    public Array<string> grouped { get; private set; }
+    public List<string> grouped { get; private set; }
     public string swallowing { get; private set; }
     public int focus_history_id { get; private set; }
 
@@ -52,9 +52,9 @@ public class Client : Object {
         fullscreen = (Fullscreen)obj.get_int_member("fullscreen");
         fullscreen_client = (Fullscreen)obj.get_int_member("fullscreenClient");
 
-        grouped = new Array<string>();
+        grouped = new List<string>();
         foreach (var addr in obj.get_array_member("grouped").get_elements())
-            grouped.append_val(addr.get_string().replace("0x", ""));
+            grouped.append(addr.get_string().replace("0x", ""));
 
         workspace = hyprland.get_workspace((int)obj.get_object_member("workspace").get_int_member("id"));
         monitor = hyprland.get_monitor((int)obj.get_int_member("monitor"));

--- a/lib/hyprland/src/client.vala
+++ b/lib/hyprland/src/client.vala
@@ -25,6 +25,7 @@ public class Client : Object {
 
     // TODO: public Group[] grouped { get; private set; }
     // TODO: public Tag[] tags { get; private set; }
+    public Array<string> grouped { get; private set; }
     public string swallowing { get; private set; }
     public int focus_history_id { get; private set; }
 
@@ -50,6 +51,10 @@ public class Client : Object {
         height = (int)obj.get_array_member("size").get_int_element(1);
         fullscreen = (Fullscreen)obj.get_int_member("fullscreen");
         fullscreen_client = (Fullscreen)obj.get_int_member("fullscreenClient");
+
+        grouped = new Array<string>();
+        foreach (var addr in obj.get_array_member("grouped").get_elements())
+            grouped.append_val(addr.get_string().replace("0x", ""));
 
         workspace = hyprland.get_workspace((int)obj.get_object_member("workspace").get_int_member("id"));
         monitor = hyprland.get_monitor((int)obj.get_int_member("monitor"));

--- a/lib/hyprland/src/client.vala
+++ b/lib/hyprland/src/client.vala
@@ -25,7 +25,7 @@ public class Client : Object {
 
     // TODO: public Group[] grouped { get; private set; }
     // TODO: public Tag[] tags { get; private set; }
-    public List<string> grouped { get; private set; }
+    public Json.Array grouped { get; private set; }
     public string swallowing { get; private set; }
     public int focus_history_id { get; private set; }
 
@@ -52,9 +52,7 @@ public class Client : Object {
         fullscreen = (Fullscreen)obj.get_int_member("fullscreen");
         fullscreen_client = (Fullscreen)obj.get_int_member("fullscreenClient");
 
-        grouped = new List<string>();
-        foreach (var addr in obj.get_array_member("grouped").get_elements())
-            grouped.append(addr.get_string().replace("0x", ""));
+        grouped = obj.get_array_member("grouped");
 
         workspace = hyprland.get_workspace((int)obj.get_object_member("workspace").get_int_member("id"));
         monitor = hyprland.get_monitor((int)obj.get_int_member("monitor"));

--- a/lib/hyprland/src/client.vala
+++ b/lib/hyprland/src/client.vala
@@ -25,8 +25,7 @@ public class Client : Object {
 
     // TODO: public Group[] grouped { get; private set; }
     // TODO: public Tag[] tags { get; private set; }
-    public List<weak string> _grouped = new List<weak string>();
-    public List<weak string> grouped { owned get { return _grouped.copy(); } }
+    public string[] grouped { get; private set; }
     public string swallowing { get; private set; }
     public int focus_history_id { get; private set; }
 
@@ -52,9 +51,15 @@ public class Client : Object {
         height = (int)obj.get_array_member("size").get_int_element(1);
         fullscreen = (Fullscreen)obj.get_int_member("fullscreen");
         fullscreen_client = (Fullscreen)obj.get_int_member("fullscreenClient");
-
-        foreach (var addr in obj.get_array_member("grouped").get_elements())
-            _grouped.append(addr.get_string().replace("0x", ""));
+        
+        string[] _grouped = {};
+        foreach (unowned Json.Node node in obj.get_array_member("grouped").get_elements()) {
+            unowned string raw_val = node.get_string();
+            if (raw_val != null) {
+                _grouped += raw_val.replace("0x", "");
+            }
+        }
+        grouped = _grouped;
 
         workspace = hyprland.get_workspace((int)obj.get_object_member("workspace").get_int_member("id"));
         monitor = hyprland.get_monitor((int)obj.get_int_member("monitor"));

--- a/lib/hyprland/src/client.vala
+++ b/lib/hyprland/src/client.vala
@@ -10,7 +10,7 @@ public class Client : Object {
     public int y { get; private set; }
     public int width { get; private set; }
     public int height { get; private set; }
-    public Group group { get; private set; }
+    public Group? group { get; private set; }
     public Workspace workspace { get; private set; }
     public bool floating { get; private set; }
     public Monitor monitor { get; private set; }

--- a/lib/hyprland/src/client.vala
+++ b/lib/hyprland/src/client.vala
@@ -25,7 +25,7 @@ public class Client : Object {
 
     // TODO: public Group[] grouped { get; private set; }
     // TODO: public Tag[] tags { get; private set; }
-    public Json.Array grouped { get; private set; }
+    public unowned List<string> grouped { get; private set; }
     public string swallowing { get; private set; }
     public int focus_history_id { get; private set; }
 
@@ -52,7 +52,9 @@ public class Client : Object {
         fullscreen = (Fullscreen)obj.get_int_member("fullscreen");
         fullscreen_client = (Fullscreen)obj.get_int_member("fullscreenClient");
 
-        grouped = obj.get_array_member("grouped");
+        grouped = new List<string>();
+        foreach (var addr in obj.get_array_member("grouped").get_elements())
+            grouped.append(addr.get_string().replace("0x", ""));
 
         workspace = hyprland.get_workspace((int)obj.get_object_member("workspace").get_int_member("id"));
         monitor = hyprland.get_monitor((int)obj.get_int_member("monitor"));

--- a/lib/hyprland/src/group.vala
+++ b/lib/hyprland/src/group.vala
@@ -19,10 +19,12 @@ public class Group : Object {
     public Workspace workspace { get; private set; }
     public Monitor monitor { get; private set; }
 
-    internal void sync(GLib.List<string>? addresses) {
+    internal void sync(GLib.List<string> addresses) {
         var hyprland = Hyprland.get_default();
         foreach (var addr in addresses) {
-            _clients.prepend(hyprland.get_client(addr));
+            var client = hyprland?.get_client(addr);
+            if (client != null)
+                _clients.prepend((owned)client);
         }
         _clients.reverse();
 

--- a/lib/hyprland/src/group.vala
+++ b/lib/hyprland/src/group.vala
@@ -3,7 +3,7 @@ public class Group : Object {
     public signal void destroyed();
     public signal void moved_to(Workspace workspace);
 
-    public weak Client primary_client { get; private set; }
+    public weak Client visible_client { get; private set; }
     private List<weak Client> _clients = new List<weak Client> ();
     public List<weak Client> clients { owned get { return _clients.copy(); } }
 
@@ -38,27 +38,32 @@ public class Group : Object {
         address = hyprland.pick_primary_address(addresses);
 
         setClientsFromAdresses(addresses);
+
+        foreach (var c in _clients) {
+            if (c.hidden == false) {
+                visible_client = c;
+                break;
+            }
+        }
         
-        primary_client = hyprland.get_client(address);
-        
-        mapped = primary_client.mapped;
-        hidden = primary_client.hidden;
-        floating = primary_client.floating;
-        pinned = primary_client.pinned;
-        x = primary_client.x;
-        y = primary_client.y;
-        width = primary_client.width;
-        height = primary_client.height;
-        workspace = primary_client.workspace;
-        monitor = primary_client.monitor;
+        mapped = visible_client.mapped;
+        hidden = visible_client.hidden;
+        floating = visible_client.floating;
+        pinned = visible_client.pinned;
+        x = visible_client.x;
+        y = visible_client.y;
+        width = visible_client.width;
+        height = visible_client.height;
+        workspace = visible_client.workspace;
+        monitor = visible_client.monitor;
     }
 
     public void focus() {
-        primary_client.focus();
+        visible_client.focus();
     }
 
     public void toggle_floating() {
-        primary_client.toggle_floating();
+        visible_client.toggle_floating();
     }
 }
 }

--- a/lib/hyprland/src/group.vala
+++ b/lib/hyprland/src/group.vala
@@ -1,0 +1,51 @@
+namespace AstalHyprland {
+public class Group : Object {
+    public signal void destroyed();
+    public signal void moved_to(Workspace workspace);
+
+    public weak Client primary_client { get; private set; }
+    private List<weak Client> _clients = new List<weak Client> ();
+    public List<weak Client> clients { owned get { return _clients.copy(); } }
+
+    public string address { get; private set; }
+    public bool mapped { get; private set; }
+    public bool hidden { get; private set; }
+    public int x { get; private set; }
+    public int y { get; private set; }
+    public int width { get; private set; }
+    public int height { get; private set; }
+    public bool floating { get; private set; }
+    public bool pinned { get; private set; }
+    public Workspace workspace { get; private set; }
+    public Monitor monitor { get; private set; }
+
+    internal void sync(GLib.List<string>? addresses) {
+        var hyprland = Hyprland.get_default();
+        foreach (var addr in addresses) {
+            _clients.prepend(hyprland.get_client(addr));
+        }
+        _clients.reverse();
+
+        primary_client = _clients.nth_data(0);
+        address = primary_client.address;
+        mapped = primary_client.mapped;
+        hidden = primary_client.hidden;
+        floating = primary_client.floating;
+        pinned = primary_client.pinned;
+        x = primary_client.x;
+        y = primary_client.y;
+        width = primary_client.width;
+        height = primary_client.height;
+        workspace = primary_client.workspace;
+        monitor = primary_client.monitor;
+    }
+
+    public void focus() {
+        primary_client.focus();
+    }
+
+    public void toggle_floating() {
+        primary_client.toggle_floating();
+    }
+}
+}

--- a/lib/hyprland/src/group.vala
+++ b/lib/hyprland/src/group.vala
@@ -19,17 +19,28 @@ public class Group : Object {
     public Workspace workspace { get; private set; }
     public Monitor monitor { get; private set; }
 
-    internal void sync(GLib.List<string> addresses) {
+    private void setClientsFromAdresses(List<string> addresses) {
         var hyprland = Hyprland.get_default();
+
+        _clients = new List<weak Client>();
         foreach (var addr in addresses) {
             var client = hyprland?.get_client(addr);
             if (client != null)
                 _clients.prepend((owned)client);
         }
         _clients.reverse();
+        notify_property("clients");
+    }
 
-        primary_client = _clients.nth_data(0);
-        address = primary_client.address;
+    internal void sync(GLib.List<string> addresses) {
+        var hyprland = Hyprland.get_default();
+
+        address = hyprland.pick_primary_address(addresses);
+
+        setClientsFromAdresses(addresses);
+        
+        primary_client = hyprland.get_client(address);
+        
         mapped = primary_client.mapped;
         hidden = primary_client.hidden;
         floating = primary_client.floating;

--- a/lib/hyprland/src/hyprland.vala
+++ b/lib/hyprland/src/hyprland.vala
@@ -376,12 +376,18 @@ public class Hyprland : Object {
 
     private void _sync_groups(Json.Array clients) throws Error {
         var grps = get_clients_group_addresses(clients);
-        foreach (var adresses in grps.get_values()) {
-            var g = get_group_from_addresses(adresses);
-            if (g != null) g.sync(adresses);
+        foreach (var addresses in grps.get_values()) {
+            if (addresses.length() == 0) continue;
+            var primary_addr = pick_primary_address(addresses);
+            var g = get_group(primary_addr);
+            if (g == null) {
+                g = new Group();
+                _groups.set(primary_addr, g);
+            }
+            g.sync(addresses);
         }
-        notify_property("groups");
         _clean_groups(clients);
+        notify_property("groups");
     }
 
     public async void sync_clients() throws Error {

--- a/lib/hyprland/src/hyprland.vala
+++ b/lib/hyprland/src/hyprland.vala
@@ -380,6 +380,7 @@ public class Hyprland : Object {
             var g = get_group_from_addresses(adresses);
             if (g != null) g.sync(adresses);
         }
+        notify_property("groups");
         _clean_groups(clients);
     }
 

--- a/lib/hyprland/src/hyprland.vala
+++ b/lib/hyprland/src/hyprland.vala
@@ -493,10 +493,7 @@ public class Hyprland : Object {
             }
             case "openwindow": {
                 var addr = args[1].split(",")[0];
-                if (yield try_add_client(addr)) {
-                    yield sync_clients();
-                    yield sync_workspaces();
-                }
+                yield try_add_client(addr);
                 break;
             }
             case "closewindow": {

--- a/lib/hyprland/src/hyprland.vala
+++ b/lib/hyprland/src/hyprland.vala
@@ -177,6 +177,12 @@ public class Hyprland : Object {
     public signal void monitor_added(Monitor monitor);
     public signal void monitor_removed(int id);
 
+    public signal void added_to_group(string address);
+    public signal void removed_from_group(string address);
+    public signal void ignoring_group_lock(int state);
+    public signal void locking_groups(int state);
+
+
     private SocketConnection socket2;
 
     private SocketConnection? connection(string socket) {
@@ -532,7 +538,6 @@ public class Hyprland : Object {
                 yield sync_clients();
                 break;
             }
-            // TODO:
             case "togglegroup": {
                 var argv = args[1].split(",");
                 yield sync_clients();
@@ -547,16 +552,20 @@ public class Hyprland : Object {
             }
             case "moveintogroup": {
                 yield sync_clients();
+                added_to_group(args[1]);
                 break;
             }
             case "moveoutofgroup": {
                 yield sync_clients();
+                removed_from_group(args[1]);
                 break;
             }
             case "ignoregrouplock":{
+                ignoring_group_lock(int.parse(args[1]));
                 break;
             }
             case "lockgroups": {
+                locking_groups(int.parse(args[1]));
                 break;
             }
             case "configreloaded": {

--- a/lib/hyprland/src/hyprland.vala
+++ b/lib/hyprland/src/hyprland.vala
@@ -499,6 +499,7 @@ public class Hyprland : Object {
             case "closewindow": {
                 _clients.get(args[1].replace("0x", "")).removed();
                 _clients.remove(args[1]);
+                yield sync_clients();
                 yield sync_workspaces();
                 client_removed(args[1]);
                 notify_property("clients");

--- a/lib/hyprland/src/workspace.vala
+++ b/lib/hyprland/src/workspace.vala
@@ -3,11 +3,13 @@ public class Workspace : Object {
     public signal void removed();
 
     public List<weak Client> _clients = new List<weak Client>();
+    public List<weak Group> _groups = new List<weak Group>();
 
     public int id { get; private set; }
     public string name { get; private set; }
     public Monitor monitor { get; private set; }
     public List<weak Client> clients { owned get { return _clients.copy(); } }
+    public List<weak Group> groups { owned get { return _groups.copy(); } }
     public bool has_fullscreen { get; private set; }
     public Client last_client { get; private set; }
 
@@ -29,6 +31,18 @@ public class Workspace : Object {
         return list;
     }
 
+    internal List<weak Group> filter_groups() {
+        var hyprland = Hyprland.get_default();
+        var list = new List<weak Group>();
+        foreach (var group in hyprland.groups) {
+            if (group.workspace == this) {
+                list.append(group);
+            }
+        }
+
+        return list;
+    }
+
     internal void sync(Json.Object obj) {
         var hyprland = Hyprland.get_default();
 
@@ -39,10 +53,16 @@ public class Workspace : Object {
         monitor = hyprland.get_monitor((int)obj.get_int_member("monitorID"));
         last_client = hyprland.get_client(obj.get_string_member("lastwindow"));
 
-        var list = filter_clients();
-        if (_clients.length() != list.length()) {
-            _clients = list.copy();
+        var clients_list = filter_clients();
+        if (_clients.length() != clients_list.length()) {
+            _clients = clients_list.copy();
             notify_property("clients");
+        }
+
+        var groups_list = filter_groups();
+        if (_groups.length() != groups_list.length()) {
+            _groups = groups_list.copy();
+            notify_property("groups");
         }
     }
 


### PR DESCRIPTION
The goal is to take `j/clients`' output and rewire the `grouped` property to integrate groups with the following
flow: `workspace -> group -> client`

Added:
- `Group` class
- `groups` property to `Hyprland` and `Workspace` 
- `focused_group` property to `Hyprland`
- `grouped` (`string[]`) and `group` (`Group`) properties to `Client`
- events related to groups listed in TODO.
- new signals related to groups

Manually tested in AGS

