### PR TITLE
[wireplumber] fix segfault from uninitialized channel_str in volume functions

### DIFF
--- a/lib/wireplumber/src/node.c
+++ b/lib/wireplumber/src/node.c
@@ -95,11 +95,13 @@ void astal_wp_node_update_volume(AstalWpNode *self) {
 
     if (channels != NULL) {
         const gchar *key;
-        const gchar *channel_str;
-        gdouble channel_volume;
+        const gchar *channel_str = NULL;
+        gdouble channel_volume = 0;
         GVariant *varvol;
 
         while (g_variant_iter_loop(channels, "{&sv}", &key, &varvol)) {
+            channel_str = NULL;
+            channel_volume = 0;
             g_variant_lookup(varvol, "volume", "d", &channel_volume);
             g_variant_lookup(varvol, "channel", "&s", &channel_str);
 
@@ -167,14 +169,17 @@ void astal_wp_node_set_channel_volume(AstalWpNode *self, const gchar *name, gdou
         g_auto(GVariantBuilder) channel_volumes_b = G_VARIANT_BUILDER_INIT(G_VARIANT_TYPE_VARDICT);
 
         const gchar *key;
-        const gchar *channel_str;
-        gdouble channel_volume;
+        const gchar *channel_str = NULL;
+        gdouble channel_volume = 0;
         GVariant *varvol;
 
         while (g_variant_iter_loop(channels, "{&sv}", &key, &varvol)) {
             g_auto(GVariantBuilder) channel_b = G_VARIANT_BUILDER_INIT(G_VARIANT_TYPE_VARDICT);
+            channel_str = NULL;
+            channel_volume = 0;
             g_variant_lookup(varvol, "volume", "d", &channel_volume);
             g_variant_lookup(varvol, "channel", "&s", &channel_str);
+            if (channel_str == NULL) continue;
             gdouble vol = g_str_equal(name, channel_str) ? volume : channel_volume;
             g_variant_builder_add(&channel_b, "{sv}", "volume", g_variant_new_double(vol));
             g_variant_builder_add(&channel_volumes_b, "{sv}", key,
@@ -221,14 +226,17 @@ void astal_wp_node_set_volume(AstalWpNode *self, gdouble volume) {
         g_auto(GVariantBuilder) channel_volumes_b = G_VARIANT_BUILDER_INIT(G_VARIANT_TYPE_VARDICT);
 
         const gchar *key;
-        const gchar *channel_str;
-        gdouble channel_volume;
+        const gchar *channel_str = NULL;
+        gdouble channel_volume = 0;
         GVariant *varvol;
 
         while (g_variant_iter_loop(channels, "{&sv}", &key, &varvol)) {
             g_auto(GVariantBuilder) channel_b = G_VARIANT_BUILDER_INIT(G_VARIANT_TYPE_VARDICT);
+            channel_str = NULL;
+            channel_volume = 0;
             g_variant_lookup(varvol, "volume", "d", &channel_volume);
             g_variant_lookup(varvol, "channel", "&s", &channel_str);
+            if (channel_str == NULL) continue;
             gdouble vol = priv->volume == 0 ? volume : channel_volume * volume / priv->volume;
             g_variant_builder_add(&channel_b, "{sv}", "volume", g_variant_new_double(vol));
             g_variant_builder_add(&channel_volumes_b, "{sv}", key,


### PR DESCRIPTION
## Problem

`g_variant_lookup()` with the `"&s"` format does **not** modify the output pointer when the key is not found. The three channel-volume iteration loops in `lib/wireplumber/src/node.c` declared `channel_str` without initializing it to `NULL`, so when a PipeWire node's `channelVolumes` variant lacks a `"channel"` entry the pointer retains its previous (or garbage) value.

- In `astal_wp_node_update_volume` the stale pointer reaches `g_hash_table_lookup(priv->channels, channel_str)`, whose `g_str_hash` key function dereferences it → **SIGSEGV**.
- In `astal_wp_node_set_channel_volume` and `astal_wp_node_set_volume` the stale pointer is passed to `g_str_equal` → **SIGSEGV**.

The existing `if (channel_str == NULL) continue` guard in `astal_wp_node_update_volume` is correct in intent but ineffective because `channel_str` is never initialized.

## Reproducer

Start an Android emulator (e.g. Android Studio AVD). The emulator registers PipeWire audio streams with non-standard channel metadata that triggers the missing-key path, causing the crash.

## Fix

- Initialize `channel_str = NULL` and `channel_volume = 0` at declaration.
- Reset both variables at the top of each loop iteration so stale values from a previous iteration cannot carry over.
- Add the missing `if (channel_str == NULL) continue` guard in `astal_wp_node_set_channel_volume` and `astal_wp_node_set_volume` (parallel to the guard already present in `astal_wp_node_update_volume`).