### PR TITLE
fix(hyprland): use new lua dispatchers

### DIFF
--- a/lib/hyprland/src/client.vala
+++ b/lib/hyprland/src/client.vala
@@ -56,20 +56,20 @@ public class Client : Object {
     }
 
     public void kill() {
-        Hyprland.get_default().dispatch("closewindow", @"address:0x$address");
+        Hyprland.get_default().dispatch("window.close", @"address:0x$address");
     }
 
     public void focus() {
-        Hyprland.get_default().dispatch("focuswindow", @"address:0x$address");
+        Hyprland.get_default().dispatch("focus", @"{window=\"address:0x$address\"}");
     }
 
     public void move_to(Workspace ws) {
         var id = ws.id;
-        Hyprland.get_default().dispatch("movetoworkspacesilent", @"$id,address:0x$address");
+        Hyprland.get_default().dispatch("window.move", @"{window=\"address:0x$address\",workspace=$id,follow=false}");
     }
 
     public void toggle_floating() {
-        Hyprland.get_default().dispatch("togglefloating", @"address:0x$address");
+        Hyprland.get_default().dispatch("window.float", @"{window=\"address:0x$address\"}");
     }
 }
 

--- a/lib/hyprland/src/client.vala
+++ b/lib/hyprland/src/client.vala
@@ -56,20 +56,40 @@ public class Client : Object {
     }
 
     public void kill() {
-        Hyprland.get_default().dispatch("window.close", @"\"address:0x$address\"");
+        if(Hyprland.get_default().config_provider == ConfigProvider.LUA) {
+            Hyprland.get_default().dispatch("window.close", @"\"address:0x$address\"");
+            return;
+        }
+
+        Hyprland.get_default().dispatch("closewindow", @"address:0x$address");
     }
 
     public void focus() {
-        Hyprland.get_default().dispatch("focus", @"{window=\"address:0x$address\"}");
+        if(Hyprland.get_default().config_provider == ConfigProvider.LUA) {
+            Hyprland.get_default().dispatch("focus", @"{window=\"address:0x$address\"}");
+            return;
+        }
+
+        Hyprland.get_default().dispatch("focuswindow", @"address:0x$address");
     }
 
     public void move_to(Workspace ws) {
         var id = ws.id.to_string();
-        Hyprland.get_default().dispatch("window.move", @"{window=\"address:0x$address\",workspace=$id,follow=false}");
+        if(Hyprland.get_default().config_provider == ConfigProvider.LUA) {
+            Hyprland.get_default().dispatch("window.move", @"{window=\"address:0x$address\",workspace=$id,follow=false}");
+            return;
+        }
+
+        Hyprland.get_default().dispatch("movetoworkspacesilent", @"$id,address:0x$address"); 
     }
 
     public void toggle_floating() {
-        Hyprland.get_default().dispatch("window.float", @"{window=\"address:0x$address\"}");
+        if(Hyprland.get_default().config_provider == ConfigProvider.LUA) {
+            Hyprland.get_default().dispatch("window.float", @"{window=\"address:0x$address\"}");
+            return;
+        }
+
+        Hyprland.get_default().dispatch("togglefloating", @"address:0x$address");
     }
 }
 

--- a/lib/hyprland/src/client.vala
+++ b/lib/hyprland/src/client.vala
@@ -56,7 +56,7 @@ public class Client : Object {
     }
 
     public void kill() {
-        Hyprland.get_default().dispatch("window.close", @"address:0x$address");
+        Hyprland.get_default().dispatch("window.close", @"\"address:0x$address\"");
     }
 
     public void focus() {
@@ -64,7 +64,7 @@ public class Client : Object {
     }
 
     public void move_to(Workspace ws) {
-        var id = ws.id;
+        var id = ws.id.to_string();
         Hyprland.get_default().dispatch("window.move", @"{window=\"address:0x$address\",workspace=$id,follow=false}");
     }
 

--- a/lib/hyprland/src/hyprland.vala
+++ b/lib/hyprland/src/hyprland.vala
@@ -199,8 +199,24 @@ public class Hyprland : Object {
         return "";
     }
 
+    /** Call a dispatcher in the Hyprland socket (without the `hl.dsp` prefix) 
+      * Please keep in mid that arguments are in the lua syntax, 
+      * you might need to add string quotes when needed
+      */
     public void dispatch(string dispatcher, string args) {
-        var msg = "dispatch " + dispatcher + " " + args;
+        var msg = "dispatch hl.dsp." + dispatcher + "(" + args + ")";
+        message_async.begin(msg, (_, res) => {
+                var err = message_async.end(res);
+                if (err != "ok") critical("dispatch error: %s", err);
+            });
+    }
+
+    /** Call a dispatcher in the Hyprland socket (without the `hl.dsp` prefix) 
+      * Please keep in mid that arguments are in the lua syntax, 
+      * you might need to add string quotes when needed
+      */
+    public void dispatch_argv(string dispatcher, string[] args) {
+        var msg = "dispatch hl.dsp." + dispatcher + "(" + string.joinv(",", args) + ")";
         message_async.begin(msg, (_, res) => {
                 var err = message_async.end(res);
                 if (err != "ok") critical("dispatch error: %s", err);
@@ -208,7 +224,7 @@ public class Hyprland : Object {
     }
 
     public void move_cursor(int x, int y) {
-        dispatch("movecursor", x.to_string() + " " + y.to_string());
+        dispatch("cursor.move", "{x=" + x.to_string() + ",y=" + y.to_string() + "}");
     }
 
     // TODO: nag vaxry to make socket events and hyprctl more consistent

--- a/lib/hyprland/src/hyprland.vala
+++ b/lib/hyprland/src/hyprland.vala
@@ -199,7 +199,8 @@ public class Hyprland : Object {
         return "";
     }
 
-    /** Call a dispatcher in the Hyprland socket (without the `hl.dsp` prefix) 
+    /**
+      * Call a dispatcher in the Hyprland socket (without the `hl.dsp` prefix) 
       * Please keep in mid that arguments are in the lua syntax, 
       * you might need to add string quotes when needed
       */
@@ -211,7 +212,8 @@ public class Hyprland : Object {
             });
     }
 
-    /** Call a dispatcher in the Hyprland socket (without the `hl.dsp` prefix) 
+    /**
+      * Call a dispatcher in the Hyprland socket (without the `hl.dsp` prefix) 
       * Please keep in mid that arguments are in the lua syntax, 
       * you might need to add string quotes when needed
       */

--- a/lib/hyprland/src/hyprland.vala
+++ b/lib/hyprland/src/hyprland.vala
@@ -45,6 +45,7 @@ public class Hyprland : Object {
     public List<weak Monitor> monitors { owned get { return _monitors.get_values(); } }
     public List<weak Workspace> workspaces { owned get { return _workspaces.get_values(); } }
     public List<weak Client> clients { owned get { return _clients.get_values(); } }
+    public ConfigProvider config_provider { get; private set; default = ConfigProvider.HYPRLANG; }
 
     public Monitor get_monitor(int id) {
         return _monitors.get(id);
@@ -200,12 +201,28 @@ public class Hyprland : Object {
     }
 
     /**
+      * Send inline lua to Hyprland. (with `LUA` config provider only)
+      */
+    public void eval(string lua) {
+        var msg = "eval " + lua;
+        message_async.begin(msg, (_, res) => {
+                var err = message_async.end(res);
+                if (err != "ok") critical("eval error: %s", err);
+            });
+    }
+
+    /**
       * Call a dispatcher in the Hyprland socket (without the `hl.dsp` prefix) 
-      * Please keep in mid that arguments are in the lua syntax, 
+      * Please keep in mind that arguments are in the lua syntax, 
       * you might need to add string quotes when needed
       */
     public void dispatch(string dispatcher, string args) {
-        var msg = "dispatch hl.dsp." + dispatcher + "(" + args + ")";
+        var msg = "dispatch ";
+        if(this.config_provider == ConfigProvider.LUA) {
+            msg = msg + "hl.dsp." + dispatcher + "(" + args + ")";
+        } else {
+            msg = msg + dispatcher + " " + args;
+        }
         message_async.begin(msg, (_, res) => {
                 var err = message_async.end(res);
                 if (err != "ok") critical("dispatch error: %s", err);
@@ -214,7 +231,7 @@ public class Hyprland : Object {
 
     /**
       * Call a dispatcher in the Hyprland socket (without the `hl.dsp` prefix) 
-      * Please keep in mid that arguments are in the lua syntax, 
+      * Please keep in mind that arguments are in the lua syntax, 
       * you might need to add string quotes when needed
       */
     public void dispatch_argv(string dispatcher, string[] args) {
@@ -226,7 +243,12 @@ public class Hyprland : Object {
     }
 
     public void move_cursor(int x, int y) {
-        dispatch("cursor.move", "{x=" + x.to_string() + ",y=" + y.to_string() + "}");
+        if(this.config_provider == ConfigProvider.LUA) {
+            dispatch("cursor.move", "{x=" + x.to_string() + ",y=" + y.to_string() + "}");
+            return;
+        }
+
+       dispatch("movecursor", x.to_string() + " " + y.to_string()); 
     }
 
     // TODO: nag vaxry to make socket events and hyprctl more consistent
@@ -234,6 +256,13 @@ public class Hyprland : Object {
         var mons = Json.from_string(message("j/monitors")).get_array();
         var wrkspcs = Json.from_string(message("j/workspaces")).get_array();
         var clnts = Json.from_string(message("j/clients")).get_array();
+        
+        try {
+            var prov = Json.from_string(message("j/status")).get_object().get_member("configProvider").get_string();
+            if (prov == "lua") {
+                this.config_provider = ConfigProvider.LUA;
+            }
+        } catch (Error _) {}
 
         // create
         foreach (var mon in mons.get_elements()) {

--- a/lib/hyprland/src/monitor.vala
+++ b/lib/hyprland/src/monitor.vala
@@ -67,7 +67,7 @@ public class AstalHyprland.Monitor : Object {
     }
 
     public void focus() {
-        Hyprland.get_default().dispatch("focusmonitor", id.to_string());
+        Hyprland.get_default().dispatch("focus", "{monitor=" + id.to_string() + "}");
     }
 
     public enum Transform {

--- a/lib/hyprland/src/monitor.vala
+++ b/lib/hyprland/src/monitor.vala
@@ -67,7 +67,12 @@ public class AstalHyprland.Monitor : Object {
     }
 
     public void focus() {
-        Hyprland.get_default().dispatch("focus", "{monitor=" + id.to_string() + "}");
+        if(Hyprland.get_default().config_provider == ConfigProvider.LUA) {
+            Hyprland.get_default().dispatch("focus", "{monitor=" + id.to_string() + "}");
+            return;
+        }
+
+        Hyprland.get_default().dispatch("focusmonitor", id.to_string());
     }
 
     public enum Transform {

--- a/lib/hyprland/src/structs.vala
+++ b/lib/hyprland/src/structs.vala
@@ -45,4 +45,9 @@ public class Position : Object {
         y = int.parse(xy[1].strip());
     }
 }
+
+public enum ConfigProvider {
+    LUA = 0,
+    HYPRLANG = 1
+}
 }

--- a/lib/hyprland/src/workspace.vala
+++ b/lib/hyprland/src/workspace.vala
@@ -47,11 +47,11 @@ public class Workspace : Object {
     }
 
     public void focus() {
-        Hyprland.get_default().dispatch("workspace", id.to_string());
+        Hyprland.get_default().dispatch("focus", "{workspace=" + id.to_string() + "}");
     }
 
     public void move_to(Monitor m) {
-        Hyprland.get_default().dispatch("moveworkspacetomonitor", id.to_string() + " " + m.id.to_string());
+        Hyprland.get_default().dispatch("workspace.move", "{workspace=" + id.to_string() + ",monitor=" + m.id.to_string() + "}");
     }
 }
 }

--- a/lib/hyprland/src/workspace.vala
+++ b/lib/hyprland/src/workspace.vala
@@ -47,11 +47,21 @@ public class Workspace : Object {
     }
 
     public void focus() {
-        Hyprland.get_default().dispatch("focus", "{workspace=" + id.to_string() + "}");
+        if(Hyprland.get_default().config_provider == ConfigProvider.LUA) {
+            Hyprland.get_default().dispatch("focus", "{workspace=" + id.to_string() + "}");
+            return;
+        }
+
+        Hyprland.get_default().dispatch("workspace", id.to_string());
     }
 
     public void move_to(Monitor m) {
-        Hyprland.get_default().dispatch("workspace.move", "{workspace=" + id.to_string() + ",monitor=" + m.id.to_string() + "}");
+        if(Hyprland.get_default().config_provider == ConfigProvider.LUA) {
+            Hyprland.get_default().dispatch("workspace.move", "{workspace=" + id.to_string() + ",monitor=" + m.id.to_string() + "}");
+            return;
+        }
+
+        Hyprland.get_default().dispatch("moveworkspacetomonitor", id.to_string() + " " + m.id.to_string());
     }
 }
 }


### PR DESCRIPTION
As of Hyprland 0.55, [lua](https://lua.org) is the default language for configuration. Because of this change, the old dispatchers are now broken in favor of `lua` dispatchers.

In short, I changed some methods to use the new dispatchers, fixing some of the broken features(e.g.: `Workspace`, `Monitor`, `Client` focus methods), while keeping backwards compatibility with `hyprlang`.

- The `Hyprland.dispatch` method adds the `hl.dsp.` dispatcher prefix (if you think this is unnecessary, let me know!).
- Added `Hyprland.dispatch_argv` for multi-argument dispatchers if needed, both `dispatch` and `dispatch_argv` are documented, by the way.
- Added `Hyprland.eval` method for evaluating inline lua through IPC.
- Added `Hyprland:config-provider`(type `Hyprland.ConfigProvider`), which specifies whether the session is using `LUA` or `HYPRLANG` for configuration. (info is grabbed from the `status` socket command)

Also, should I add a `Client.close` method? Hyprland has two dispatchers, both for killing(force-closing) and closing a client. Currently, the `Client.kill` method calls the `window.close` dispatcher, which doesn't really match with the method's name.
If we do this, we might have to deprecate `Client.kill`(for compatibility reasons) and add a `Client.force_close()` method to actually kill the client instead of closing.


Any suggestions are welcome :D