### PR TITLE
fix: incremental builds failing due to gir.py

### DIFF
--- a/lib/gir.py
+++ b/lib/gir.py
@@ -64,6 +64,7 @@ def _valadoc(name: str, gir: str, pkgs: str, sources: list[str]):
         *["-o", "docs"],
         *["--package-name", name],
         *["--gir", gir],
+        "--force",
         *[f"--pkg={pkg}" for pkg in pkglist if pkg != ""],
         *sources,
     ]


### PR DESCRIPTION
gir.py uses Valadoc to generate GIRs. This causes all incremental builds to fail, because Valadoc complains about the docs/ directory in build/ (which we don't even use for anything, it's just a side effect of generating the GIR) already existing.

Adding --force to the Valadoc invocation allows overwriting it, and makes incremental builds possible.