### PR TITLE
fix(network): network device hot-plugging

### DIFF
--- a/lib/network/src/accesspoint.vala
+++ b/lib/network/src/accesspoint.vala
@@ -16,6 +16,8 @@ public class AstalNetwork.AccessPoint : Object {
     public NM.80211ApSecurityFlags wpa_flags { get { return ap.wpa_flags; } }
 
     public GenericArray<NM.RemoteConnection> get_connections() {
+        if (wifi.device == null) return new GenericArray<NM.RemoteConnection>();
+
         return (GenericArray<NM.RemoteConnection>)ap.filter_connections(
             wifi.device.client.connections
         );
@@ -65,6 +67,9 @@ public class AstalNetwork.AccessPoint : Object {
      * Returns whether the connection is the new active connection.
      */
     public async void activate(string? password = null) throws Error {
+        var wifi_device = wifi.device;
+        if (wifi_device == null) return;
+
         var conns = get_connections();
 
         if (conns.length > 0) {
@@ -78,7 +83,7 @@ public class AstalNetwork.AccessPoint : Object {
 
             yield ap.client.activate_connection_async(
                 first_conn,
-                wifi.device,
+                wifi_device,
                 get_path(),
                 null
             );
@@ -97,7 +102,7 @@ public class AstalNetwork.AccessPoint : Object {
 
             yield ap.client.add_and_activate_connection_async(
                 connection,
-                wifi.device,
+                wifi_device,
                 get_path(),
                 null
             );

--- a/lib/network/src/accesspoint.vala
+++ b/lib/network/src/accesspoint.vala
@@ -1,6 +1,7 @@
 public class AstalNetwork.AccessPoint : Object {
     private Wifi wifi;
     public NM.AccessPoint ap;
+    private ulong notify_handler = 0;
 
     public uint bandwidth { get { return ap.bandwidth; } }
     public string bssid { owned get { return ap.bssid; } }
@@ -43,12 +44,19 @@ public class AstalNetwork.AccessPoint : Object {
         this.wifi = wifi;
         this.ap = ap;
 
-        ap.notify.connect((pspec) => {
+        notify_handler = ap.notify.connect((pspec) => {
             if (get_class().find_property(pspec.name) != null) notify_property(pspec.name);
             if (pspec.name == "strength") icon_name = _icon();
         });
 
         icon_name = _icon();
+    }
+
+    internal void disconnect_signals() {
+        if (notify_handler > 0) {
+            SignalHandler.disconnect(ap, notify_handler);
+            notify_handler = 0;
+        }
     }
 
     /**

--- a/lib/network/src/network.vala
+++ b/lib/network/src/network.vala
@@ -16,6 +16,7 @@ public class AstalNetwork.Network : Object {
     public Wifi? wifi { get; private set; }
     public Wired? wired { get; private set; }
     public Primary primary { get; private set; }
+    private bool sync_queued = false;
 
     public Connectivity connectivity {
         get { return (Connectivity)client.connectivity; }
@@ -28,15 +29,13 @@ public class AstalNetwork.Network : Object {
     construct {
         try {
             client = new NM.Client();
-            var wifi_device = (NM.DeviceWifi)get_device(NM.DeviceType.WIFI);
-            if (wifi_device != null) wifi = new Wifi(wifi_device);
-
-            var ethernet = (NM.DeviceEthernet)get_device(NM.DeviceType.ETHERNET);
-            if (ethernet != null) wired = new Wired(ethernet);
+            sync_devices();
 
             sync();
-            client.notify["primary-connection"].connect(sync);
-            client.notify["activating-connection"].connect(sync);
+            client.notify["primary-connection"].connect(queue_sync);
+            client.notify["activating-connection"].connect(queue_sync);
+            client.device_added.connect(queue_sync);
+            client.device_removed.connect(on_device_removed);
 
             client.notify["state"].connect(() => notify_property("state"));
             client.notify["connectivity"].connect(() => notify_property("connectivity"));
@@ -58,6 +57,53 @@ public class AstalNetwork.Network : Object {
         if (valid.length > 0) return valid.get(0);
 
         return null;
+    }
+
+    private void queue_sync() {
+        if (sync_queued) return;
+
+        sync_queued = true;
+        Idle.add(() => {
+            sync_queued = false;
+            sync_devices();
+            sync();
+
+            return Source.REMOVE;
+        });
+    }
+
+    private void on_device_removed(NM.Device device) {
+        if ((wifi != null) && (wifi.device == device)) {
+            wifi.disconnect_signals();
+            wifi = null;
+        }
+
+        if ((wired != null) && (wired.device == device)) {
+            wired.disconnect_signals();
+            wired = null;
+        }
+
+        queue_sync();
+    }
+
+    private void sync_devices() {
+        var wifi_device = (NM.DeviceWifi)get_device(NM.DeviceType.WIFI);
+        if (wifi_device == null) {
+            if (wifi != null) wifi.disconnect_signals();
+            wifi = null;
+        } else if ((wifi == null) || (wifi.device != wifi_device)) {
+            if (wifi != null) wifi.disconnect_signals();
+            wifi = new Wifi(wifi_device);
+        }
+
+        var ethernet = (NM.DeviceEthernet)get_device(NM.DeviceType.ETHERNET);
+        if (ethernet == null) {
+            if (wired != null) wired.disconnect_signals();
+            wired = null;
+        } else if ((wired == null) || (wired.device != ethernet)) {
+            if (wired != null) wired.disconnect_signals();
+            wired = new Wired(ethernet);
+        }
     }
 
     private void sync() {

--- a/lib/network/src/network.vala
+++ b/lib/network/src/network.vala
@@ -13,8 +13,8 @@ public class AstalNetwork.Network : Object {
 
     public NM.Client client { get; private set; }
 
-    public Wifi? wifi { get; private set; }
-    public Wired? wired { get; private set; }
+    public Wifi wifi { get; private set; }
+    public Wired wired { get; private set; }
     public Primary primary { get; private set; }
     private bool sync_queued = false;
     private bool sync_wifi_queued = false;
@@ -31,6 +31,8 @@ public class AstalNetwork.Network : Object {
     construct {
         try {
             client = new NM.Client();
+            wifi = new Wifi();
+            wired = new Wired();
             sync_devices();
 
             sync();
@@ -101,14 +103,14 @@ public class AstalNetwork.Network : Object {
     }
 
     private void on_device_removed(NM.Device device) {
-        if ((wifi != null) && (wifi.device == device)) {
-            wifi.disconnect_signals();
-            wifi = null;
+        if (wifi.device == device) {
+            wifi.sync_device(null);
+            notify_property("wifi");
         }
 
-        if ((wired != null) && (wired.device == device)) {
-            wired.disconnect_signals();
-            wired = null;
+        if (wired.device == device) {
+            wired.sync_device(null);
+            notify_property("wired");
         }
 
         queue_sync_device_type(device.device_type);
@@ -120,25 +122,17 @@ public class AstalNetwork.Network : Object {
     }
 
     private void sync_wifi() {
+        var old_device = wifi.device;
         var wifi_device = (NM.DeviceWifi)get_device(NM.DeviceType.WIFI);
-        if (wifi_device == null) {
-            if (wifi != null) wifi.disconnect_signals();
-            wifi = null;
-        } else if ((wifi == null) || (wifi.device != wifi_device)) {
-            if (wifi != null) wifi.disconnect_signals();
-            wifi = new Wifi(wifi_device);
-        }
+        wifi.sync_device(wifi_device);
+        if (old_device != wifi.device) notify_property("wifi");
     }
 
     private void sync_wired() {
+        var old_device = wired.device;
         var ethernet = (NM.DeviceEthernet)get_device(NM.DeviceType.ETHERNET);
-        if (ethernet == null) {
-            if (wired != null) wired.disconnect_signals();
-            wired = null;
-        } else if ((wired == null) || (wired.device != ethernet)) {
-            if (wired != null) wired.disconnect_signals();
-            wired = new Wired(ethernet);
-        }
+        wired.sync_device(ethernet);
+        if (old_device != wired.device) notify_property("wired");
     }
 
     private void sync() {

--- a/lib/network/src/network.vala
+++ b/lib/network/src/network.vala
@@ -17,6 +17,8 @@ public class AstalNetwork.Network : Object {
     public Wired? wired { get; private set; }
     public Primary primary { get; private set; }
     private bool sync_queued = false;
+    private bool sync_wifi_queued = false;
+    private bool sync_wired_queued = false;
 
     public Connectivity connectivity {
         get { return (Connectivity)client.connectivity; }
@@ -32,9 +34,11 @@ public class AstalNetwork.Network : Object {
             sync_devices();
 
             sync();
-            client.notify["primary-connection"].connect(queue_sync);
-            client.notify["activating-connection"].connect(queue_sync);
-            client.device_added.connect(queue_sync);
+            client.notify["primary-connection"].connect(queue_sync_all);
+            client.notify["activating-connection"].connect(queue_sync_all);
+            client.device_added.connect((device) => {
+                queue_sync_device_type(device.device_type);
+            });
             client.device_removed.connect(on_device_removed);
 
             client.notify["state"].connect(() => notify_property("state"));
@@ -59,17 +63,41 @@ public class AstalNetwork.Network : Object {
         return null;
     }
 
+    private void queue_sync_all() {
+        sync_wifi_queued = true;
+        sync_wired_queued = true;
+        queue_sync();
+    }
+
     private void queue_sync() {
         if (sync_queued) return;
 
         sync_queued = true;
         Idle.add(() => {
             sync_queued = false;
-            sync_devices();
+            if (sync_wifi_queued) sync_wifi();
+            if (sync_wired_queued) sync_wired();
+            sync_wifi_queued = false;
+            sync_wired_queued = false;
             sync();
 
             return Source.REMOVE;
         });
+    }
+
+    private void queue_sync_device_type(NM.DeviceType device_type) {
+        switch (device_type) {
+            case NM.DeviceType.WIFI:
+                sync_wifi_queued = true;
+                break;
+            case NM.DeviceType.ETHERNET:
+                sync_wired_queued = true;
+                break;
+            default:
+                return;
+        }
+
+        queue_sync();
     }
 
     private void on_device_removed(NM.Device device) {
@@ -83,10 +111,15 @@ public class AstalNetwork.Network : Object {
             wired = null;
         }
 
-        queue_sync();
+        queue_sync_device_type(device.device_type);
     }
 
     private void sync_devices() {
+        sync_wifi();
+        sync_wired();
+    }
+
+    private void sync_wifi() {
         var wifi_device = (NM.DeviceWifi)get_device(NM.DeviceType.WIFI);
         if (wifi_device == null) {
             if (wifi != null) wifi.disconnect_signals();
@@ -95,7 +128,9 @@ public class AstalNetwork.Network : Object {
             if (wifi != null) wifi.disconnect_signals();
             wifi = new Wifi(wifi_device);
         }
+    }
 
+    private void sync_wired() {
         var ethernet = (NM.DeviceEthernet)get_device(NM.DeviceType.ETHERNET);
         if (ethernet == null) {
             if (wired != null) wired.disconnect_signals();

--- a/lib/network/src/wifi.vala
+++ b/lib/network/src/wifi.vala
@@ -14,7 +14,7 @@ public class AstalNetwork.Wifi : Object {
     private HashTable<string, AccessPoint> _access_points =
         new HashTable<string, AccessPoint>(str_hash, str_equal);
 
-    public NM.DeviceWifi device { get; construct set; }
+    public NM.DeviceWifi? device { get; private set; }
 
     public NM.ActiveConnection? active_connection { get; private set; }
     private ulong connection_handler = 0;
@@ -34,8 +34,10 @@ public class AstalNetwork.Wifi : Object {
     }
 
     public bool enabled {
-        get { return device.client.wireless_enabled; }
-        set { device.client.wireless_enabled = value; }
+        get { return (device != null) && device.client.wireless_enabled; }
+        set {
+            if (device != null) device.client.wireless_enabled = value;
+        }
     }
 
     public Internet internet { get; private set; }
@@ -46,39 +48,47 @@ public class AstalNetwork.Wifi : Object {
     public DeviceState state { get; private set; }
     public string icon_name { get; private set; }
     public bool is_hotspot { get; private set; }
+    public bool is_active { get; private set; }
     public bool scanning { get; private set; }
 
     public signal void access_point_added(AccessPoint ap) ;
     public signal void access_point_removed(AccessPoint ap) ;
 
-    internal Wifi(NM.DeviceWifi device) {
-        this.device = device;
+    internal Wifi() {
+        reset();
+    }
 
-        foreach (var ap in device.access_points) {
-            var new_ap = new AccessPoint(this, ap);
-            _access_points.set(ap.bssid, new_ap);
-            access_point_added(new_ap);
+    internal void sync_device(NM.DeviceWifi? device) {
+        if (this.device == device) return;
+
+        disconnect_signals();
+        this.device = device;
+        notify_property("device");
+
+        if (device == null) {
+            reset();
+            return;
         }
 
+        update_is_active(true);
+        foreach (var ap in device.access_points) {
+            add_access_point(ap);
+        }
+        notify_property("access-points");
+
         device_access_point_added_handler = device.access_point_added.connect((access_point) => {
-            var ap = (NM.AccessPoint)access_point;
-            var new_ap = new AccessPoint(this, ap);
-            _access_points.set(ap.bssid, new_ap);
-            access_point_added(new_ap);
+            add_access_point((NM.AccessPoint)access_point);
             notify_property("access-points");
         });
 
         device_access_point_removed_handler = device.access_point_removed.connect((access_point) => {
-            var ap = (NM.AccessPoint)access_point;
-            var rem_ap = _access_points.get(ap.bssid);
-            _access_points.remove(ap.bssid);
-            if (rem_ap != null) rem_ap.disconnect_signals();
-            if (rem_ap != null) access_point_removed(rem_ap);
+            remove_access_point((NM.AccessPoint)access_point);
             notify_property("access-points");
         });
 
         on_active_connection();
-        device_active_connection_handler = device.notify["active-connection"].connect(on_active_connection);
+        device_active_connection_handler =
+            device.notify["active-connection"].connect(on_active_connection);
 
         on_active_access_point();
         device_active_access_point_handler =
@@ -106,11 +116,7 @@ public class AstalNetwork.Wifi : Object {
     );
 
     internal void disconnect_signals() {
-        if ((connection_handler > 0) && (active_connection != null)) {
-            SignalHandler.disconnect(active_connection, connection_handler);
-            connection_handler = 0;
-        }
-        active_connection = null;
+        disconnect_connection_signal();
 
         if ((ap_handler > 0) && (active_access_point != null)) {
             SignalHandler.disconnect(active_access_point, ap_handler);
@@ -118,67 +124,73 @@ public class AstalNetwork.Wifi : Object {
         }
         active_access_point = null;
 
-        if (device_active_connection_handler > 0) {
+        if ((device_active_connection_handler > 0) && (device != null)) {
             SignalHandler.disconnect(device, device_active_connection_handler);
             device_active_connection_handler = 0;
         }
 
-        if (device_active_access_point_handler > 0) {
+        if ((device_active_access_point_handler > 0) && (device != null)) {
             SignalHandler.disconnect(device, device_active_access_point_handler);
             device_active_access_point_handler = 0;
         }
 
-        if (device_access_point_added_handler > 0) {
+        if ((device_access_point_added_handler > 0) && (device != null)) {
             SignalHandler.disconnect(device, device_access_point_added_handler);
             device_access_point_added_handler = 0;
         }
 
-        if (device_access_point_removed_handler > 0) {
+        if ((device_access_point_removed_handler > 0) && (device != null)) {
             SignalHandler.disconnect(device, device_access_point_removed_handler);
             device_access_point_removed_handler = 0;
         }
 
-        if (device_state_handler > 0) {
+        if ((device_state_handler > 0) && (device != null)) {
             SignalHandler.disconnect(device, device_state_handler);
             device_state_handler = 0;
         }
 
-        if (client_wireless_handler > 0) {
+        if ((client_wireless_handler > 0) && (device != null)) {
             SignalHandler.disconnect(device.client, client_wireless_handler);
             client_wireless_handler = 0;
         }
 
         if (client_connectivity_handler > 0) {
-            SignalHandler.disconnect(device.client, client_connectivity_handler);
+            if (device != null) SignalHandler.disconnect(device.client, client_connectivity_handler);
             client_connectivity_handler = 0;
         }
 
-        foreach (var ap in _access_points.get_values()) {
-            ap.disconnect_signals();
-        }
-        _access_points.remove_all();
+        clear_access_points();
     }
 
     public void scan() {
+        if (device == null) return;
+
+        var scan_device = device;
         scanning = true;
-        var last_scan = device.last_scan;
-        device.request_scan_async.begin(null, (_, res) => {
+        var last_scan = scan_device.last_scan;
+        scan_device.request_scan_async.begin(null, (_, res) => {
             try {
-                device.request_scan_async.end(res);
+                scan_device.request_scan_async.end(res);
                 Timeout.add(1000, () => {
-                    if (device.last_scan == last_scan) return Source.CONTINUE;
+                    if (device != scan_device) {
+                        scanning = false;
+                        return Source.REMOVE;
+                    }
+
+                    if (scan_device.last_scan == last_scan) return Source.CONTINUE;
 
                     scanning = false;
                     return Source.REMOVE;
                 }, Priority.DEFAULT);
             } catch (Error err) {
+                scanning = false;
                 critical(err.message);
             }
         });
     }
 
     public async void deactivate_connection() throws Error {
-        if (device.active_connection == null) {
+        if ((device == null) || (device.active_connection == null)) {
             return;
         }
 
@@ -186,10 +198,12 @@ public class AstalNetwork.Wifi : Object {
     }
 
     private void on_active_connection() {
-        if ((connection_handler > 0) && (active_connection != null)) {
-            SignalHandler.disconnect(active_connection, connection_handler);
-            connection_handler = 0;
-            active_connection = null;
+        disconnect_connection_signal();
+
+        if (device == null) {
+            reset_connection();
+            icon_name = _icon();
+            return;
         }
 
         active_connection = device.active_connection;
@@ -219,17 +233,55 @@ public class AstalNetwork.Wifi : Object {
             active_access_point = null;
         }
 
+        if (device == null) return;
+
         var ap = device.active_access_point;
         if (ap != null) {
             active_access_point = _access_points.get(ap.bssid);
             if (active_access_point != null) {
                 on_active_access_point_notify();
                 ap_handler = active_access_point.notify.connect(on_active_access_point_notify);
+                return;
             }
         }
+
+        reset_access_point();
+        icon_name = _icon();
+    }
+
+    private void add_access_point(NM.AccessPoint ap) {
+        var old_ap = _access_points.get(ap.bssid);
+        if (old_ap != null) {
+            old_ap.disconnect_signals();
+            access_point_removed(old_ap);
+        }
+
+        var new_ap = new AccessPoint(this, ap);
+        _access_points.set(ap.bssid, new_ap);
+        access_point_added(new_ap);
+    }
+
+    private void remove_access_point(NM.AccessPoint ap) {
+        var rem_ap = _access_points.get(ap.bssid);
+        if (rem_ap == null) return;
+
+        rem_ap.disconnect_signals();
+        _access_points.remove(ap.bssid);
+        access_point_removed(rem_ap);
+    }
+
+    private void clear_access_points() {
+        foreach (var ap in _access_points.get_values()) {
+            ap.disconnect_signals();
+            access_point_removed(ap);
+        }
+
+        _access_points.remove_all();
+        notify_property("access-points");
     }
 
     private string _icon() {
+        if (device == null) return ICON_OFFLINE;
         if (!enabled) return ICON_DISABLED;
 
         var full = device.client.connectivity == NM.ConnectivityState.FULL;
@@ -254,7 +306,47 @@ public class AstalNetwork.Wifi : Object {
         return ICON_OFFLINE;
     }
 
+    private void reset_connection() {
+        active_connection = null;
+        is_hotspot = false;
+        internet = Internet.DISCONNECTED;
+    }
+
+    private void disconnect_connection_signal() {
+        if ((connection_handler > 0) && (active_connection != null)) {
+            SignalHandler.disconnect(active_connection, connection_handler);
+            connection_handler = 0;
+        }
+
+        active_connection = null;
+    }
+
+    private void update_is_active(bool active) {
+        if (is_active == active) return;
+
+        is_active = active;
+        notify_property("is-active");
+    }
+
+    private void reset_access_point() {
+        active_access_point = null;
+        bandwidth = 0;
+        frequency = 0;
+        strength = 0;
+        ssid = "";
+    }
+
+    private void reset() {
+        update_is_active(false);
+        reset_connection();
+        reset_access_point();
+        state = DeviceState.UNKNOWN;
+        scanning = false;
+        icon_name = _icon();
+    }
+
     private bool _hotspot() {
+        if (device == null) return false;
         if (device.active_connection == null) return false;
 
         var conn = device.active_connection.connection;

--- a/lib/network/src/wifi.vala
+++ b/lib/network/src/wifi.vala
@@ -18,9 +18,16 @@ public class AstalNetwork.Wifi : Object {
 
     public NM.ActiveConnection? active_connection { get; private set; }
     private ulong connection_handler = 0;
+    private ulong device_active_connection_handler = 0;
 
     public AccessPoint? active_access_point { get; private set; }
     private ulong ap_handler = 0;
+    private ulong device_active_access_point_handler = 0;
+    private ulong device_access_point_added_handler = 0;
+    private ulong device_access_point_removed_handler = 0;
+    private ulong device_state_handler = 0;
+    private ulong client_wireless_handler = 0;
+    private ulong client_connectivity_handler = 0;
 
     public List<weak AccessPoint> access_points {
         owned get { return _access_points.get_values(); }
@@ -53,7 +60,7 @@ public class AstalNetwork.Wifi : Object {
             access_point_added(new_ap);
         }
 
-        device.access_point_added.connect((access_point) => {
+        device_access_point_added_handler = device.access_point_added.connect((access_point) => {
             var ap = (NM.AccessPoint)access_point;
             var new_ap = new AccessPoint(this, ap);
             _access_points.set(ap.bssid, new_ap);
@@ -61,29 +68,34 @@ public class AstalNetwork.Wifi : Object {
             notify_property("access-points");
         });
 
-        device.access_point_removed.connect((access_point) => {
+        device_access_point_removed_handler = device.access_point_removed.connect((access_point) => {
             var ap = (NM.AccessPoint)access_point;
             var rem_ap = _access_points.get(ap.bssid);
             _access_points.remove(ap.bssid);
+            if (rem_ap != null) rem_ap.disconnect_signals();
             access_point_removed(rem_ap);
             notify_property("access-points");
         });
 
         on_active_connection();
-        device.notify["active-connection"].connect(on_active_connection);
+        device_active_connection_handler = device.notify["active-connection"].connect(on_active_connection);
 
         on_active_access_point();
-        device.notify["active-access-point"].connect(on_active_access_point);
+        device_active_access_point_handler =
+            device.notify["active-access-point"].connect(on_active_access_point);
 
         state = (DeviceState)device.state;
-        device.client.notify["wireless-enabled"].connect(() => notify_property("enabled"));
-        device.state_changed.connect((n, o, r) => {
+        client_wireless_handler = device.client.notify["wireless-enabled"].connect(() => {
+            notify_property("enabled");
+            icon_name = _icon();
+        });
+        device_state_handler = device.state_changed.connect((n, o, r) => {
             state_changed(n, o, r);
             state = (DeviceState)n;
         });
 
-        device.notify.connect(() => { icon_name = _icon(); });
-        device.client.notify.connect(() => { icon_name = _icon(); });
+        client_connectivity_handler =
+            device.client.notify["connectivity"].connect(() => { icon_name = _icon(); });
         icon_name = _icon();
     }
 
@@ -92,6 +104,57 @@ public class AstalNetwork.Wifi : Object {
         DeviceState old_state,
         NM.DeviceStateReason reaseon
     );
+
+    internal void disconnect_signals() {
+        if ((connection_handler > 0) && (active_connection != null)) {
+            SignalHandler.disconnect(active_connection, connection_handler);
+            connection_handler = 0;
+        }
+
+        if ((ap_handler > 0) && (active_access_point != null)) {
+            SignalHandler.disconnect(active_access_point, ap_handler);
+            ap_handler = 0;
+        }
+
+        if (device_active_connection_handler > 0) {
+            SignalHandler.disconnect(device, device_active_connection_handler);
+            device_active_connection_handler = 0;
+        }
+
+        if (device_active_access_point_handler > 0) {
+            SignalHandler.disconnect(device, device_active_access_point_handler);
+            device_active_access_point_handler = 0;
+        }
+
+        if (device_access_point_added_handler > 0) {
+            SignalHandler.disconnect(device, device_access_point_added_handler);
+            device_access_point_added_handler = 0;
+        }
+
+        if (device_access_point_removed_handler > 0) {
+            SignalHandler.disconnect(device, device_access_point_removed_handler);
+            device_access_point_removed_handler = 0;
+        }
+
+        if (device_state_handler > 0) {
+            SignalHandler.disconnect(device, device_state_handler);
+            device_state_handler = 0;
+        }
+
+        if (client_wireless_handler > 0) {
+            SignalHandler.disconnect(device.client, client_wireless_handler);
+            client_wireless_handler = 0;
+        }
+
+        if (client_connectivity_handler > 0) {
+            SignalHandler.disconnect(device.client, client_connectivity_handler);
+            client_connectivity_handler = 0;
+        }
+
+        foreach (var ap in _access_points.get_values()) {
+            ap.disconnect_signals();
+        }
+    }
 
     public void scan() {
         scanning = true;
@@ -121,18 +184,21 @@ public class AstalNetwork.Wifi : Object {
 
     private void on_active_connection() {
         if ((connection_handler > 0) && (active_connection != null)) {
-            active_connection.disconnect(connection_handler);
+            SignalHandler.disconnect(active_connection, connection_handler);
             connection_handler = 0;
             active_connection = null;
         }
 
         active_connection = device.active_connection;
         is_hotspot = _hotspot();
+        internet = Internet.from_device(device);
         if (active_connection != null) {
             connection_handler = active_connection.notify["state"].connect(() => {
                 internet = Internet.from_device(device);
+                icon_name = _icon();
             });
         }
+        icon_name = _icon();
     }
 
     private void on_active_access_point_notify() {
@@ -140,11 +206,12 @@ public class AstalNetwork.Wifi : Object {
         frequency = active_access_point.frequency;
         strength = active_access_point.strength;
         ssid = active_access_point.ssid;
+        icon_name = _icon();
     }
 
     private void on_active_access_point() {
         if ((ap_handler > 0) && (active_access_point != null)) {
-            active_access_point.disconnect(ap_handler);
+            SignalHandler.disconnect(active_access_point, ap_handler);
             ap_handler = 0;
             active_access_point = null;
         }

--- a/lib/network/src/wifi.vala
+++ b/lib/network/src/wifi.vala
@@ -73,7 +73,7 @@ public class AstalNetwork.Wifi : Object {
             var rem_ap = _access_points.get(ap.bssid);
             _access_points.remove(ap.bssid);
             if (rem_ap != null) rem_ap.disconnect_signals();
-            access_point_removed(rem_ap);
+            if (rem_ap != null) access_point_removed(rem_ap);
             notify_property("access-points");
         });
 
@@ -110,11 +110,13 @@ public class AstalNetwork.Wifi : Object {
             SignalHandler.disconnect(active_connection, connection_handler);
             connection_handler = 0;
         }
+        active_connection = null;
 
         if ((ap_handler > 0) && (active_access_point != null)) {
             SignalHandler.disconnect(active_access_point, ap_handler);
             ap_handler = 0;
         }
+        active_access_point = null;
 
         if (device_active_connection_handler > 0) {
             SignalHandler.disconnect(device, device_active_connection_handler);
@@ -154,6 +156,7 @@ public class AstalNetwork.Wifi : Object {
         foreach (var ap in _access_points.get_values()) {
             ap.disconnect_signals();
         }
+        _access_points.remove_all();
     }
 
     public void scan() {
@@ -219,8 +222,10 @@ public class AstalNetwork.Wifi : Object {
         var ap = device.active_access_point;
         if (ap != null) {
             active_access_point = _access_points.get(ap.bssid);
-            on_active_access_point_notify();
-            ap_handler = active_access_point.notify.connect(on_active_access_point_notify);
+            if (active_access_point != null) {
+                on_active_access_point_notify();
+                ap_handler = active_access_point.notify.connect(on_active_access_point_notify);
+            }
         }
     }
 

--- a/lib/network/src/wired.vala
+++ b/lib/network/src/wired.vala
@@ -8,6 +8,10 @@ public class AstalNetwork.Wired : Object {
 
     public NM.ActiveConnection connection;
     private ulong connection_handler = 0;
+    private ulong device_active_connection_handler = 0;
+    private ulong device_speed_handler = 0;
+    private ulong device_state_handler = 0;
+    private ulong client_connectivity_handler = 0;
 
     internal Wired(NM.DeviceEthernet device) {
         this.device = device;
@@ -16,20 +20,14 @@ public class AstalNetwork.Wired : Object {
         state = (DeviceState)device.state;
         icon_name = _icon();
 
-        device.notify.connect((pspec) => {
-            if (pspec.name == "speed") {
-                speed = device.speed;
-            }
-            if (pspec.name == "state") {
-                state = (DeviceState)device.state;
-            }
-            if (pspec.name == "active-connection") {
-                on_active_connection();
-            }
-            icon_name = _icon();
-        });
+        device_speed_handler = device.notify["speed"].connect(() => { speed = device.speed; });
+        device_state_handler =
+            device.notify["state"].connect(() => { state = (DeviceState)device.state; });
+        device_active_connection_handler =
+            device.notify["active-connection"].connect(on_active_connection);
 
-        device.client.notify.connect(() => { icon_name = _icon(); });
+        client_connectivity_handler =
+            device.client.notify["connectivity"].connect(() => { icon_name = _icon(); });
 
         on_active_connection();
         icon_name = _icon();
@@ -37,16 +35,46 @@ public class AstalNetwork.Wired : Object {
 
     private void on_active_connection() {
         if ((connection_handler > 0) && (connection != null)) {
-            connection.disconnect(connection_handler);
+            SignalHandler.disconnect(connection, connection_handler);
             connection_handler = 0;
             connection = null;
         }
 
         connection = device.active_connection;
+        internet = Internet.from_device(device);
         if (connection != null) {
             connection_handler = connection.notify["state"].connect(() => {
                 internet = Internet.from_device(device);
+                icon_name = _icon();
             });
+        }
+        icon_name = _icon();
+    }
+
+    internal void disconnect_signals() {
+        if ((connection_handler > 0) && (connection != null)) {
+            SignalHandler.disconnect(connection, connection_handler);
+            connection_handler = 0;
+        }
+
+        if (device_active_connection_handler > 0) {
+            SignalHandler.disconnect(device, device_active_connection_handler);
+            device_active_connection_handler = 0;
+        }
+
+        if (device_speed_handler > 0) {
+            SignalHandler.disconnect(device, device_speed_handler);
+            device_speed_handler = 0;
+        }
+
+        if (device_state_handler > 0) {
+            SignalHandler.disconnect(device, device_state_handler);
+            device_state_handler = 0;
+        }
+
+        if (client_connectivity_handler > 0) {
+            SignalHandler.disconnect(device.client, client_connectivity_handler);
+            client_connectivity_handler = 0;
         }
     }
 

--- a/lib/network/src/wired.vala
+++ b/lib/network/src/wired.vala
@@ -4,22 +4,34 @@ public class AstalNetwork.Wired : Object {
     private const string ICON_ACQUIRING = "network-wired-acquiring-symbolic";
     private const string ICON_NO_ROUTE = "network-wired-no-route-symbolic";
 
-    public NM.DeviceEthernet device { get; construct set; }
+    public NM.DeviceEthernet? device { get; private set; }
 
-    public NM.ActiveConnection connection;
+    public NM.ActiveConnection? connection;
     private ulong connection_handler = 0;
     private ulong device_active_connection_handler = 0;
     private ulong device_speed_handler = 0;
     private ulong device_state_handler = 0;
     private ulong client_connectivity_handler = 0;
 
-    internal Wired(NM.DeviceEthernet device) {
-        this.device = device;
+    internal Wired() {
+        reset();
+    }
 
+    internal void sync_device(NM.DeviceEthernet? device) {
+        if (this.device == device) return;
+
+        disconnect_signals();
+        this.device = device;
+        notify_property("device");
+
+        if (device == null) {
+            reset();
+            return;
+        }
+
+        update_is_active(true);
         speed = device.speed;
         state = (DeviceState)device.state;
-        icon_name = _icon();
-
         device_speed_handler = device.notify["speed"].connect(() => { speed = device.speed; });
         device_state_handler =
             device.notify["state"].connect(() => { state = (DeviceState)device.state; });
@@ -34,10 +46,12 @@ public class AstalNetwork.Wired : Object {
     }
 
     private void on_active_connection() {
-        if ((connection_handler > 0) && (connection != null)) {
-            SignalHandler.disconnect(connection, connection_handler);
-            connection_handler = 0;
-            connection = null;
+        disconnect_connection_signal();
+
+        if (device == null) {
+            reset_connection();
+            icon_name = _icon();
+            return;
         }
 
         connection = device.active_connection;
@@ -52,28 +66,24 @@ public class AstalNetwork.Wired : Object {
     }
 
     internal void disconnect_signals() {
-        if ((connection_handler > 0) && (connection != null)) {
-            SignalHandler.disconnect(connection, connection_handler);
-            connection_handler = 0;
-        }
-        connection = null;
+        disconnect_connection_signal();
 
-        if (device_active_connection_handler > 0) {
+        if ((device_active_connection_handler > 0) && (device != null)) {
             SignalHandler.disconnect(device, device_active_connection_handler);
             device_active_connection_handler = 0;
         }
 
-        if (device_speed_handler > 0) {
+        if ((device_speed_handler > 0) && (device != null)) {
             SignalHandler.disconnect(device, device_speed_handler);
             device_speed_handler = 0;
         }
 
-        if (device_state_handler > 0) {
+        if ((device_state_handler > 0) && (device != null)) {
             SignalHandler.disconnect(device, device_state_handler);
             device_state_handler = 0;
         }
 
-        if (client_connectivity_handler > 0) {
+        if ((client_connectivity_handler > 0) && (device != null)) {
             SignalHandler.disconnect(device.client, client_connectivity_handler);
             client_connectivity_handler = 0;
         }
@@ -83,8 +93,40 @@ public class AstalNetwork.Wired : Object {
     public Internet internet { get; private set; }
     public DeviceState state { get; private set; }
     public string icon_name { get; private set; }
+    public bool is_active { get; private set; }
+
+    private void reset_connection() {
+        connection = null;
+        internet = Internet.DISCONNECTED;
+    }
+
+    private void disconnect_connection_signal() {
+        if ((connection_handler > 0) && (connection != null)) {
+            SignalHandler.disconnect(connection, connection_handler);
+            connection_handler = 0;
+        }
+
+        connection = null;
+    }
+
+    private void update_is_active(bool active) {
+        if (is_active == active) return;
+
+        is_active = active;
+        notify_property("is-active");
+    }
+
+    private void reset() {
+        update_is_active(false);
+        reset_connection();
+        speed = 0;
+        state = DeviceState.UNKNOWN;
+        icon_name = _icon();
+    }
 
     private string _icon() {
+        if (device == null) return ICON_DISCONNECTED;
+
         var full = device.client.connectivity == NM.ConnectivityState.FULL;
 
         if (internet == Internet.CONNECTING) {

--- a/lib/network/src/wired.vala
+++ b/lib/network/src/wired.vala
@@ -56,6 +56,7 @@ public class AstalNetwork.Wired : Object {
             SignalHandler.disconnect(connection, connection_handler);
             connection_handler = 0;
         }
+        connection = null;
 
         if (device_active_connection_handler > 0) {
             SignalHandler.disconnect(device, device_active_connection_handler);


### PR DESCRIPTION
# Summary
Fixes NetworkManager device not updating after hot-pluggin a network device in AstalNetwork.

Previously, `Network.wifi` and `Network.wired` were only populated during initialization. Starting AGS/Astal before plugging in a USB Ethernet adapter or USB WiFi adapter and would leave the corresponding device object as `null`.

This updates the network module to refresh the relevant device wrapper when NetworkManager reports a device add/remove event. Wired-only events only refresh wired state, and WiFi-only events only refresh WiFi state.

This also keeps Network.wifi and Network.wired as stable wrapper objects instead of setting them to null when their device is missing making it easier for users to keep their bindings active if a device is removed or changed.

This also adds `is_active` to Wifi and Wired so users can check if the device is present on NetworkManager. 


# Verification
- `nix build .#network` builds Astal fully.
- Tested on a Framework Laptop by launching AGS before and after plugging/un-plugging an Ethernet card.
- Confirmed `Network.wired/wifi.is_active` updates from `false` to `true` after plugging in a Ethernet card.
- Confirmed unplug/replug works without NetworkManager or Astal critical warnings.