### PR TITLE
fix(tray): guard on_item_unregister against items that never became ready

### DIFF
--- a/lib/tray/src/cli.vala
+++ b/lib/tray/src/cli.vala
@@ -35,7 +35,7 @@ int main(string[] argv) {
             id, item.to_json_string());
             stdout.flush();
 
-            item.changed.connect(() => {
+            item.changed.connect((item) => {
                 stdout.printf("{\"event\":\"item_changed\",\"id\":\"%s\",\"item\":%s}\n",
                 id, item.to_json_string());
                 stdout.flush();

--- a/lib/tray/src/tray.vala
+++ b/lib/tray/src/tray.vala
@@ -36,6 +36,8 @@ public class Tray : Object {
 
     private HashTable<string, TrayItem> _items =
         new HashTable<string, TrayItem>(str_hash, str_equal);
+    private HashTable<string, TrayItem> _pending_items =
+        new HashTable<string, TrayItem>(str_hash, str_equal);
 
     /**
      * List of currently registered tray items
@@ -139,7 +141,12 @@ public class Tray : Object {
 
         var parts = service.split("/", 2);
         TrayItem item = new TrayItem(parts[0], "/" + parts[1]);
-        item.ready.connect(() => {
+        _pending_items.set(service, item);
+        item.ready.connect((item) => {
+            if(!_pending_items.contains(service)) {
+                return;
+            }
+            _pending_items.remove(service);
             _items.set(service, item);
             _items_store.append(item);
             item_added(service);
@@ -147,18 +154,18 @@ public class Tray : Object {
     }
 
     private void on_item_unregister(string service) {
-        var item = _items.get(service);
-        _items.remove(service);
-
-        // the item never became ready (it unregistered right after registering,
-        // e.g. during startup churn), so it was never added to the store and
-        // item_added never fired for it
-        if (item == null) return;
-
-        uint pos;
-        if (_items_store.find(item, out pos)) {
-            _items_store.remove(pos);
+        if(_pending_items.contains(service)) {
+            _pending_items.remove(service);
+            return;
         }
+        var item = _items.lookup(service);
+        if(item == null) {
+            return;
+        }
+        uint pos;
+        if(!_items_store.find(item, out pos)) return;
+        _items.remove(service);
+        _items_store.remove(pos);
         item_removed(service);
     }
 

--- a/lib/tray/src/tray.vala
+++ b/lib/tray/src/tray.vala
@@ -149,9 +149,16 @@ public class Tray : Object {
     private void on_item_unregister(string service) {
         var item = _items.get(service);
         _items.remove(service);
+
+        // the item never became ready (it unregistered right after registering,
+        // e.g. during startup churn), so it was never added to the store and
+        // item_added never fired for it
+        if (item == null) return;
+
         uint pos;
-        _items_store.find(item, out pos);
-        _items_store.remove(pos);
+        if (_items_store.find(item, out pos)) {
+            _items_store.remove(pos);
+        }
         item_removed(service);
     }
 


### PR DESCRIPTION
## The bug

`Tray.on_item_unregister` ignores the boolean returned by `ListStore.find()` and unconditionally calls `remove(pos)` with a `pos` that is undefined when the item wasn't found:

```vala
uint pos;
_items_store.find(item, out pos);   // return value ignored
_items_store.remove(pos);           // pos is undefined when find() returned false
```

When a StatusNotifierItem unregisters **before its `ready` callback ever fired**, it was never appended to `_items_store` (and `item_added` never fired for it). `_items.get(service)` returns `null`, `find(null)` fails, and the stale `pos` produces, deterministically on every boot of a tray host:

```
GLib-GIO-CRITICAL **: g_list_store_remove: assertion '!g_sequence_iter_is_end (it)' failed
```

This happens reliably during startup churn — apps re-registering when a freshly started shell takes ownership of `org.kde.StatusNotifierWatcher`.

## Evidence

Captured with `G_DEBUG=fatal-criticals` on a GTK4/gjs shell (AGS v3) using AstalTray; the relevant frames of the coredump backtrace:

```
#5  g_log ()                    at /usr/lib/libglib-2.0.so.0
#6  ??? ()                      at /usr/lib/libastal-tray.so.0.1.0
#7  g_closure_invoke ()         at /usr/lib/libgobject-2.0.so.0
...
#11 g_signal_emit ()            at /usr/lib/libgobject-2.0.so.0
#12 ??? ()                      at /usr/lib/libastal-tray.so.0.1.0
#13 ??? ()                      at /usr/lib/libgio-2.0.so.0   (GDBus signal dispatch)
```

i.e. the DBus `StatusNotifierItemUnregistered` signal → `on_item_unregister` → `g_list_store_remove` assertion.

## The fix

Bail out when the service was never tracked (symmetry: `item_added` never fired for it, so `item_removed` shouldn't either), and only `remove()` when `find()` actually located the item.

## Verification

Built `lib/tray` with this patch and booted the same shell against the patched library: the boot-time CRITICAL is gone (previously 1 per boot, deterministic across 3 consecutive boots), tray fully functional, no new warnings.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)