### PR TITLE
fix(mpris): don't block player availability on cover caching

### DIFF
--- a/lib/mpris/src/player.vala
+++ b/lib/mpris/src/player.vala
@@ -775,9 +775,9 @@ public class AstalMpris.Player : Object {
             sync(yield proxy.get_all(MediaPlayerProxy.NAME));
             sync(yield proxy.get_all(PlayerProxy.NAME));
             yield check_position();
-            yield cache_cover();
             available = true;
             init_position_poll();
+            cache_cover.begin();
         } catch (Error error) {
             critical(error.message);
         }


### PR DESCRIPTION
This changes player initialization so MPRIS players become available before cover art caching completes.

Some players, notably Spotify, can delay or block artwork fetching after an AGS reload. Because `available` was only set after `yield cache_cover()`, the player could remain hidden until another state change happened.

Cover caching is not required for player discovery or control, so this patch starts it asynchronously with `cache_cover.begin()` after the player is already marked available.