### PR TITLE
fix(`apps`): update list on app install/remove operations

### DIFF
--- a/lib/apps/src/apps.vala
+++ b/lib/apps/src/apps.vala
@@ -7,6 +7,7 @@ public class AstalApps.Apps : Object {
     private string cache_directory;
     private string cache_file;
     private List<Application> _list;
+    private AppInfoMonitor monitor;
     private HashTable<string, int> frequents { get; private set; }
 
     /**
@@ -65,7 +66,8 @@ public class AstalApps.Apps : Object {
         cache_file = cache_directory + "/apps-frequents.json";
         frequents = new HashTable<string, int>(str_hash, str_equal);
 
-        AppInfoMonitor.get().changed.connect(() => {
+        monitor = AppInfoMonitor.get();
+        monitor.changed.connect(() => {
             reload();
         });
 
@@ -210,6 +212,7 @@ public class AstalApps.Apps : Object {
         }
 
         cache();
+        notify_property("list");
     }
 
     private void cache() {


### PR DESCRIPTION
### description

`Apps.list` didn't update when apps were installed or removed due to:

- `construct` connected to `AppInfoMonitor.get().changed` but was never keping reference to the monitor, so it got freed and `changed` never fired causing `reload()` to never trigger.
- `reload()` wasnt emitting `notify::list`, so even a manual reload didn't notify anything bound to `list`.

so I chnaged it by holding the monitor, and call `notify_property("list")` at the end of `reload()`.