### PR TITLE
fix(wireplumber): correct output-route-id property name typo

### DIFF
--- a/lib/wireplumber/src/endpoint.c
+++ b/lib/wireplumber/src/endpoint.c
@@ -421,7 +421,7 @@ static void astal_wp_endpoint_init(AstalWpEndpoint *self) {
     priv->device_signal_group = g_signal_group_new(ASTAL_WP_TYPE_DEVICE);
     g_signal_group_connect_swapped(priv->device_signal_group, "notify::routes",
                                    G_CALLBACK(astal_wp_endpoint_reemit_route_signals), self);
-    g_signal_group_connect_swapped(priv->device_signal_group, "notify::ouput-route-id",
+    g_signal_group_connect_swapped(priv->device_signal_group, "notify::output-route-id",
                                    G_CALLBACK(astal_wp_endpoint_reemit_route_signals), self);
     g_signal_group_connect_swapped(priv->device_signal_group, "notify::input-route-id",
                                    G_CALLBACK(astal_wp_endpoint_reemit_route_signals), self);


### PR DESCRIPTION
`astal_wp_endpoint_init` connected its device signal group to `notify::ouput-route-id` (missing a `t`). The actual property registered on `AstalWpDevice` is `output-route-id` (`device.c`), so the connection never fired and output route changes were never re-emitted on endpoints (`default-speaker`/`default-microphone`), leaving route descriptions stale until another route signal happened to fire.

One-character fix; the sibling subscriptions (`routes`, `input-route-id`) already use the correct names.