### PR TITLE
Fix for #461 - prevent error state when turning monitor on and off

### DIFF
--- a/lib/hyprland/src/hyprland.vala
+++ b/lib/hyprland/src/hyprland.vala
@@ -144,8 +144,8 @@ public class Hyprland : Object {
                         } catch (Error err) {
                             critical(err.message);
                         }
+                        watch_socket(stream);
                     });
-                    watch_socket(stream);
                 } catch (Error err) {
                     critical(err.message);
                 }
@@ -332,8 +332,10 @@ public class Hyprland : Object {
                 break;
             }
             case "monitorremoved": {
-                var id = get_monitor_by_name(args[1]).id;
-                _monitors.get(id).removed();
+                var monitor = get_monitor_by_name(args[1]);
+                if (monitor == null) break;
+                var id = monitor.id;
+                monitor.removed();
                 _monitors.remove(id);
                 monitor_removed(id);
                 notify_property("monitors");


### PR DESCRIPTION
* Fixes https://github.com/Aylur/astal/issues/461
* I'm unsure if the watch_socket change is wanted. As far as I understand the code the next message could be processed asynchronously (which was were the initial bug was happening) and now the current message needs to be processed before the code can look at the next one.
* The code below was just necessary to prevent error reporting when monitor became null. It didn't influence behaviour otherwise.
* I've checked the repo out locally and build ags with following command and tested it: 
```sh
nix build --override-input astal "git+file://$HOME/git/github/Aylur/astal" 'github:aylur/ags/v3.1.2#agsFull' -o result-ags-local && ./result-ags-local/bin/ags run
```

I'm a dev, but don't really have much vala knowledge. If you require any changes I am happy to do so, but larger changes to change the message handling might require someone knowledgable, but I would still happy to try.

Thanks for any attention and input.