### PR TITLE
AstalWl: fix roundtrips

### DIFF
--- a/lib/river/src/river.vala
+++ b/lib/river/src/river.vala
@@ -73,6 +73,7 @@ public class River : Object {
 
     private void handle_output_added(AstalWl.Output wl_output) {
         var output = new Output(wl_output, this, river_status);
+        output.output.invalidate.connect((o) => this.handle_output_removed(o));
         this._outputs.append(output);
         this.output_added(output);
         this.notify_property("outputs");
@@ -181,7 +182,7 @@ public class River : Object {
         };
         CallbackResult result = CallbackResult() {};
         cb.add_listener(cb_listener, &result);
-        this.astal_registry.get_display().roundtrip();
+        this.astal_registry.roundtrip();
         output = result.msg;
         return result.success;
     }
@@ -241,11 +242,17 @@ public class River : Object {
             this.layout_manager = this.astal_registry.get_registry().bind(layout_global.name, ref RiverLayoutManagerV3.iface, uint.min(layout_global.version, 2));
         }
 
-        this.astal_registry.get_outputs().foreach(output => this.handle_output_added(output));
-        this.astal_registry.output_added.connect((o) => this.handle_output_added(o));
-        this.astal_registry.output_removed.connect((o) => this.handle_output_removed(o));
+        for (var i = 0; i < this.astal_registry.output_list_model.get_n_items(); ++i) {
+            this.handle_output_added(this.astal_registry.output_list_model.get_item(i) as AstalWl.Output);
+        }
 
-        this.astal_registry.get_display().roundtrip();
+        this.astal_registry.output_list_model.items_changed.connect((p, r, a) => {
+            for (; a > 0; a--) {
+                this.handle_output_added(this.astal_registry.output_list_model.get_item(p++) as AstalWl.Output);
+            }
+        });
+
+        this.astal_registry.roundtrip();
     }
 }
 }

--- a/lib/wl/meson.build
+++ b/lib/wl/meson.build
@@ -11,6 +11,8 @@ project(
   ],
 )
 
+add_project_arguments('-DG_LOG_DOMAIN="AstalWl"', language: 'c')
+
 version = meson.project_version()
 name = meson.project_name()
 version_split = version.split('.')

--- a/lib/wl/output.vala
+++ b/lib/wl/output.vala
@@ -40,6 +40,8 @@ public class Output : Object {
     private Wl.Output output;
     private ZxdgOutputV1? xdg_output;
 
+    public signal void invalidate();
+
     /**
      * Returns the underlying `wl_output` proxy pointer.
      */
@@ -203,7 +205,6 @@ public class Output : Object {
             this.pending_physical_height = null;
         }
         
-        this.name = this.pending_name;
         if (this.xdg_output == null) {
             this.geometry.x = (int)(this.output_geometry.x / this.scale);
             this.geometry.y = (int)(this.output_geometry.y / this.scale);

--- a/lib/wl/output.vala
+++ b/lib/wl/output.vala
@@ -56,77 +56,91 @@ public class Output : Object {
      * This reflects the visible area after applying scaling and transform.
      */
     public Rectangle? geometry { get; private set; }
+    public Rectangle? pending_geometry;
     private Rectangle? output_geometry { get; private set; }
     /**
      * The physical width of the output in millimeters.
      */
     public int physical_width { get; private set; }
+    public int? pending_physical_width;
     /**
      * The physical height of the output in millimeters.
      */
     public int physical_height { get; private set; }
+    public int? pending_physical_height;
     /**
      * The refresh rate of the current output mode in Hz.
      */
     public double refresh_rate { get; private set; }
+    public double? pending_refresh_rate;
     /**
      * The rotation or flip transform of the output surface.
      */
     public Transform transform { get; private set; }
+    public Transform? pending_transform;
     /**
      * The subpixel layout of the physical monitor.
      */
     public Subpixel subpixel { get; private set; }
+    public Subpixel? pending_subpixel;
     /**
      * The manufacturer name of the display device.
      */
     public string? make { get; private set; }
+    public string? pending_make;
     /**
      * The product or model name of the display device.
      */
     public string? model { get; private set; }
+    public string? pending_model;
     /**
      * The scaling factor of the output.
      */
     public double scale { get; private set; }
+    public double? pending_scale;
     /**
      * The compositor-assigned name of this output.
      * Usually corresponds to an identifier like "HDMI-A-1".
      */
     public string? name { get; private set; }
+    public string? pending_name;
     /**
      * A description of the output.
      */
     public string? description { get; private set; }
+    public string? pending_description;
+
+    /**
+     * emitted whenever there were changes on any property
+     */
+    public signal void changed();
 
     private void handle_geometry (Wl.Output wl_output, int32 x, int32 y, int32 physical_width, int32 physical_height, int32 subpixel, string make, string model, int32 transform) {
-        this.freeze_notify();
         this.output_geometry.x = x;
         this.output_geometry.y = y;
-        this.subpixel = subpixel;
-        this.make = make;
-        this.model = model;
-        this.transform = transform;
-        switch (this.transform) {
+        this.pending_subpixel = subpixel;
+        this.pending_make = make;
+        this.pending_model = model;
+        this.pending_transform = transform;
+        switch (this.pending_transform) {
             case ROTATE_90:
             case ROTATE_270:
             case FLIPPED_90:
             case FLIPPED_270:
-                this.physical_width = physical_height;
-                this.physical_height = physical_width;
+                this.pending_physical_width = physical_height;
+                this.pending_physical_height = physical_width;
                 break;
             default:
-                this.physical_width = physical_width;
-                this.physical_height = physical_height;
+                this.pending_physical_width = physical_width;
+                this.pending_physical_height = physical_height;
                 break;
         }
-        this.thaw_notify();
     }
 
     private void handle_mode (Wl.Output wl_output, uint32 flags, int32 width, int32 height, int32 refresh) {
         if ((flags & 1) == 0) return;
-        this.freeze_notify();
-        switch (this.transform) {
+        Transform transform = this.pending_transform != null ? this.pending_transform : this.transform;
+        switch (transform) {
             case ROTATE_90:
             case ROTATE_270:
             case FLIPPED_90:
@@ -139,11 +153,57 @@ public class Output : Object {
                 this.output_geometry.width = width;
                 break;
         }
-        this.refresh_rate = refresh / 1000;
-        this.thaw_notify();
+        this.pending_refresh_rate = refresh / 1000;
     }
 
     private void handle_done (Wl.Output wl_output) {
+        this.freeze_notify();
+        if(this.pending_name != null) {
+            this.name = this.pending_name;
+            this.pending_name = null;
+        }
+        if(this.pending_description != null) {
+            this.description = this.pending_description;
+            this.pending_description = null;
+        }
+        if(this.pending_make != null) {
+            this.make = this.pending_make;
+            this.pending_make = null;
+        }
+        if(this.pending_model != null) {
+            this.model = this.pending_model;
+            this.pending_model = null;
+        }
+        if(this.pending_scale != null) {
+            this.scale = this.pending_scale;
+            this.pending_scale = null;
+        }
+        if(this.pending_refresh_rate != null) {
+            this.refresh_rate = this.pending_refresh_rate;
+            this.pending_refresh_rate = null;
+        }
+        if(this.pending_geometry != null) {
+            this.geometry = this.pending_geometry.copy();
+            this.pending_geometry = null;
+        }
+        if(this.pending_subpixel != null) {
+            this.subpixel = this.pending_subpixel;
+            this.pending_subpixel = null;
+        }
+        if(this.pending_transform != null) {
+            this.transform = this.pending_transform;
+            this.pending_transform = null;
+        }
+        if(this.pending_physical_width != null) {
+            this.physical_width = this.pending_physical_width;
+            this.pending_physical_width = null;
+        }
+        if(this.pending_physical_height != null) {
+            this.physical_height = this.pending_physical_height;
+            this.pending_physical_height = null;
+        }
+        
+        this.name = this.pending_name;
         if (this.xdg_output == null) {
             this.geometry.x = (int)(this.output_geometry.x / this.scale);
             this.geometry.y = (int)(this.output_geometry.y / this.scale);
@@ -165,28 +225,32 @@ public class Output : Object {
                     this.output_geometry.height / (double)this.geometry.height);
         }
         this.notify_property("geometry");
+
+        this.thaw_notify();
     }
 
     private void handle_scale (Wl.Output wl_output, int32 factor) {
-        this.scale = factor;
+        this.pending_scale = factor;
     }
 
     private void handle_name(Wl.Output wl_output, string name) {
-        this.name = name;
+        this.pending_name = name;
     }
 
     private void handle_description (Wl.Output wl_output, string description) {
-        this.description = description;
+        this.pending_description = description;
     }
 
     private void handle_xdg_logical_position(ZxdgOutputV1 zxdg_output_v1, int32 x, int32 y) {
-        this.geometry.x = x;
-        this.geometry.y = y;
+        if(this.pending_geometry == null) this.pending_geometry = Rectangle();
+        this.pending_geometry.x = x;
+        this.pending_geometry.y = y;
     }
 
     private void handle_xdg_logical_size(ZxdgOutputV1 zxdg_output_v1, int32 width, int32 height) {
-        this.geometry.width = width;
-        this.geometry.height = height;
+        if(this.pending_geometry == null) this.pending_geometry = Rectangle();
+        this.pending_geometry.width = width;
+        this.pending_geometry.height = height;
     }
 
     /**
@@ -229,6 +293,7 @@ public class Output : Object {
     internal Output(Global global, Wl.Registry registry, Wl.Display display, ZxdgOutputManagerV1 output_manager) {
         Object(id: global.name);
         this.geometry = Rectangle();
+        this.pending_geometry = Rectangle();
         this.output_geometry = Rectangle();
         this.output = registry.bind<Wl.Output>(global.name, ref wl_output_interface, uint.min(global.version, 4));
         this.output.add_listener(output_listener, this);

--- a/lib/wl/output.vala
+++ b/lib/wl/output.vala
@@ -227,6 +227,7 @@ public class Output : Object {
         this.notify_property("geometry");
 
         this.thaw_notify();
+        changed();
     }
 
     private void handle_scale (Wl.Output wl_output, int32 factor) {

--- a/lib/wl/output.vala
+++ b/lib/wl/output.vala
@@ -64,53 +64,53 @@ public class Output : Object {
      * The physical width of the output in millimeters.
      */
     public int physical_width { get; private set; }
-    public int? pending_physical_width;
+    private int? pending_physical_width;
     /**
      * The physical height of the output in millimeters.
      */
     public int physical_height { get; private set; }
-    public int? pending_physical_height;
+    private int? pending_physical_height;
     /**
      * The refresh rate of the current output mode in Hz.
      */
     public double refresh_rate { get; private set; }
-    public double? pending_refresh_rate;
+    private double? pending_refresh_rate;
     /**
      * The rotation or flip transform of the output surface.
      */
     public Transform transform { get; private set; }
-    public Transform? pending_transform;
+    private Transform? pending_transform;
     /**
      * The subpixel layout of the physical monitor.
      */
     public Subpixel subpixel { get; private set; }
-    public Subpixel? pending_subpixel;
+    private Subpixel? pending_subpixel;
     /**
      * The manufacturer name of the display device.
      */
     public string? make { get; private set; }
-    public string? pending_make;
+    private string? pending_make;
     /**
      * The product or model name of the display device.
      */
     public string? model { get; private set; }
-    public string? pending_model;
+    private string? pending_model;
     /**
      * The scaling factor of the output.
      */
     public double scale { get; private set; }
-    public double? pending_scale;
+    private double? pending_scale;
     /**
      * The compositor-assigned name of this output.
      * Usually corresponds to an identifier like "HDMI-A-1".
      */
     public string? name { get; private set; }
-    public string? pending_name;
+    private string? pending_name;
     /**
      * A description of the output.
      */
     public string? description { get; private set; }
-    public string? pending_description;
+    private string? pending_description;
 
     /**
      * emitted whenever there were changes on any property

--- a/lib/wl/output.vala
+++ b/lib/wl/output.vala
@@ -224,7 +224,6 @@ public class Output : Object {
     internal void init_xdg(ZxdgOutputManagerV1 output_manager, Wl.Display display) {
         this.xdg_output = output_manager.get_xdg_output(this.output);
         this.xdg_output.add_listener(xdg_output_listener, this);
-        display.roundtrip();
     }
 
     internal Output(Global global, Wl.Registry registry, Wl.Display display, ZxdgOutputManagerV1 output_manager) {
@@ -233,7 +232,6 @@ public class Output : Object {
         this.output_geometry = Rectangle();
         this.output = registry.bind<Wl.Output>(global.name, ref wl_output_interface, uint.min(global.version, 4));
         this.output.add_listener(output_listener, this);
-        display.roundtrip();
         if (output_manager != null) init_xdg(output_manager, display);
     }
 }

--- a/lib/wl/registry.vala
+++ b/lib/wl/registry.vala
@@ -340,9 +340,9 @@ public class Registry : Object {
         this.seats = new HashTable<uint32, Seat>(direct_hash, direct_equal);
         this.seat_list_model = new ListStore(typeof(Seat));
         
-        switch(GLib.Environment.get_variable("ASTAL_WL_DISPLAY")) {
-            case "gdk":
-            case "gtk":
+        switch(GLib.Environment.get_variable("ASTAL_WL_DISPLAY")?.up()) {
+            case "GDK":
+            case "GTK":
                 debug("forcing the use of gdk display");
                 this.display = get_wl_display();
                 break;
@@ -354,7 +354,7 @@ public class Registry : Object {
                     this.display = this.source.display;
                 }
                 break;
-            case "astal":
+            case "ASTAL":
             default:
                 debug("forcing the use of astal display");
                 this.source = new Source();

--- a/lib/wl/registry.vala
+++ b/lib/wl/registry.vala
@@ -339,13 +339,25 @@ public class Registry : Object {
         this.seats = new HashTable<uint32, Seat>(direct_hash, direct_equal);
         this.seat_list_model = new ListStore(typeof(Seat));
         
-
-        this.display = get_wl_display();
-
-        if (this.display == null) {
-            debug("Could not find Gdk Wayland Display, falling back to creating a new Wayland Display");
-            this.source = new Source();
-            this.display = this.source.display;
+        switch(GLib.Environment.get_variable("ASTAL_WL_DISPLAY")) {
+            case "gdk":
+            case "gtk":
+                debug("forcing the use of gdk display");
+                this.display = get_wl_display();
+                break;
+            case null:
+                this.display = get_wl_display();
+                if(this.display == null) {
+                    debug("could not connect to gdk display, falling back to astal");
+                    this.source = new Source();
+                    this.display = this.source.display;
+                }
+                break;
+            case "astal":
+            default:
+                debug("forcing the use of astal display");
+                this.source = new Source();
+                this.display = this.source.display;
         }
 
         if (this.display == null) {

--- a/lib/wl/registry.vala
+++ b/lib/wl/registry.vala
@@ -18,6 +18,16 @@ public struct Global {
      */
     uint32 version;
 }
+
+internal class SourceFuncWrapper {
+
+    internal SourceFunc fun;
+
+    internal SourceFuncWrapper(owned SourceFunc fun) {
+        this.fun = (owned)fun;
+    }
+}
+
 /**
  * Convenience wrapper for [func@AstalWl.Registry.get_default].
  *
@@ -35,6 +45,7 @@ public Registry get_default() {
  * signals when globals, outputs or seats are added or removed.
  */
 public class Registry : Object {
+
     private static Registry? instance;
 
     /**
@@ -52,6 +63,15 @@ public class Registry : Object {
     private Wl.Registry registry;
     private unowned Wl.Display display;
     private ZxdgOutputManagerV1 output_manager;
+
+    private const Wl.RegistryListener registry_listener = {
+        registry_handle_global_added,
+        registry_handle_global_removed,
+    };
+
+    private const Wl.CallbackListener async_roundtrip_listener = {
+        handle_async_roundtrip
+    };
 
     /**
      * Hash table of all known Wayland globals keyed by their numeric ID.
@@ -128,11 +148,33 @@ public class Registry : Object {
     }
 
     /**
-    * Returns the underlying `wl_display` used by this registry.
-    */
+     * Returns the underlying `wl_display` used by this registry.
+     */
     [GIR(visible = false)]
     public unowned Wl.Display? get_display() {
         return this.display;
+    }
+
+    /**
+     * Block until all pending requests have been handled by the compositor. Returns the number of dispatched events.
+     */
+    public int roundtrip() {
+        return this.display.roundtrip();
+    }
+
+    private static void handle_async_roundtrip(owned SourceFuncWrapper func, Wl.Callback cb, uint32 data) {
+        SourceFunc callback = func.fun;
+        callback();
+    }
+
+    /**
+     * makes an asynchronous roundtrip invoking the callback when done without blocking in the main thread.
+     */
+    public async void roundtrip_async() {
+        unowned Wl.Callback callback = this.display.sync();
+        SourceFunc callback_func = this.roundtrip_async.callback;
+        callback.add_listener(async_roundtrip_listener, new SourceFuncWrapper((owned) callback_func));
+        yield;
     }
 
     private void registry_handle_global_added (Wl.Registry wl_registry, uint32 name, string @interface, uint32 version) {
@@ -235,11 +277,6 @@ public class Registry : Object {
         return null;
     }
 
-    private const Wl.RegistryListener registry_listener = {
-        registry_handle_global_added,
-        registry_handle_global_removed,
-    };
-   
     /**
     * Looks up a seat by its global id.
     */

--- a/lib/wl/registry.vala
+++ b/lib/wl/registry.vala
@@ -169,8 +169,9 @@ public class Registry : Object {
     }
 
     private static void handle_async_roundtrip(owned SourceFuncWrapper func, Wl.Callback cb, uint32 data) {
-        SourceFunc callback = func.fun;
-        callback();
+        if(func != null && func.fun != null) {
+            func.fun();
+        }
     }
 
     /**

--- a/lib/wl/registry.vala
+++ b/lib/wl/registry.vala
@@ -199,8 +199,8 @@ public class Registry : Object {
         } else if (@interface == "wl_output") {
             var output = new Output(global, this.registry, this.display, this.output_manager);
             ulong id = 0;
-            id = output.changed.connect(() => {
-               (this.output_list_model as ListStore).append(output);
+            id = output.changed.connect((o) => {
+               (this.output_list_model as ListStore).append(o);
                 output.disconnect(id);
             });
             this.outputs.insert(name, output);
@@ -223,6 +223,7 @@ public class Registry : Object {
             uint pos;
             (this.output_list_model as ListStore).find(output, out pos);
             (this.output_list_model as ListStore).remove(pos);
+            output.invalidate();
             output_removed(output);
         } else if (global.interface == "wl_seat") {
             var seat = this.seats.lookup(name);

--- a/lib/wl/registry.vala
+++ b/lib/wl/registry.vala
@@ -107,8 +107,12 @@ public class Registry : Object {
         return this.outputs.get_values();
     }
 
+    public ListModel output_list_model { get; private set; }
+
     /**
-     * Emitted after a new [class@AstalWl.Output] has been created and bound.
+     * Emitted after a new [class@AstalWl.Output] has been created and bound, note that when this signal is emitted,
+     * the output might not have received all events yet, so its properties might no have been set to the correct values yet.
+     * If you are only interested ni outputs that have been fully initialized, use the ListModel api.
      */
     public signal void output_added(Output output);
 
@@ -128,6 +132,8 @@ public class Registry : Object {
     public List<weak Seat> get_seats() {
         return this.seats.get_values();
     }
+    
+    public ListModel seat_list_model { get; private set; }
 
     /**
      * Emitted after a new [class@AstalWl.Seat] has been created and bound.
@@ -192,11 +198,17 @@ public class Registry : Object {
             }
         } else if (@interface == "wl_output") {
             var output = new Output(global, this.registry, this.display, this.output_manager);
+            ulong id = 0;
+            id = output.changed.connect(() => {
+               (this.output_list_model as ListStore).append(output);
+                output.disconnect(id);
+            });
             this.outputs.insert(name, output);
             output_added(output);
         } else if (@interface == "wl_seat") {
             var seat = new Seat(global, this.registry, this.display);
             this.seats.insert(name, seat);
+            (this.seat_list_model as ListStore).append(seat);
             seat_added(seat);
         }
         global_added(global);
@@ -208,10 +220,16 @@ public class Registry : Object {
         if (global.interface == "wl_output") {
             var output = this.outputs.lookup(name);
             this.outputs.remove(name);
+            uint pos;
+            (this.output_list_model as ListStore).find(output, out pos);
+            (this.output_list_model as ListStore).remove(pos);
             output_removed(output);
         } else if (global.interface == "wl_seat") {
             var seat = this.seats.lookup(name);
             this.seats.remove(name);
+            uint pos;
+            (this.seat_list_model as ListStore).find(seat, out pos);
+            (this.seat_list_model as ListStore).remove(pos);
             seat_removed(seat);
         }
         global_removed(global);
@@ -316,7 +334,10 @@ public class Registry : Object {
     construct {
         this.globals = new HashTable<uint32, Global?>(direct_hash, direct_equal);
         this.outputs = new HashTable<uint32, Output>(direct_hash, direct_equal);
+        this.output_list_model = new ListStore(typeof(Output));
         this.seats = new HashTable<uint32, Seat>(direct_hash, direct_equal);
+        this.seat_list_model = new ListStore(typeof(Seat));
+        
 
         this.display = get_wl_display();
 

--- a/lib/wl/seat.vala
+++ b/lib/wl/seat.vala
@@ -61,7 +61,6 @@ public class Seat : Object {
         Object(id: global.name);
         this.seat = registry.bind<Wl.Seat>(global.name, ref wl_seat_interface, uint.min(global.version, 10));
         this.seat.add_listener(seat_listener, this);
-        display.roundtrip();
     }
 }
 }

--- a/lib/wl/wl_display.c
+++ b/lib/wl/wl_display.c
@@ -14,5 +14,7 @@ struct wl_display* astal_wl_get_wl_display() {
     if (!get_wl_display_func)
         return NULL;
 
-    return get_wl_display_func(get_gdk_display_func());
+    void* display = get_gdk_display_func();
+    if(!display) return NULL;
+    return get_wl_display_func(display);
 }


### PR DESCRIPTION
as discussed in #459 some roundtrip calls in the AstalWl lib can cause issues, so i removed them, I also added an async roundtrip function, which might come in handy in some cases.

#### Changes:
- the AstalWl.Output properties are not updated atomically once the done event is received
- removed the roundtrip in the AstalWl.Output constructor, therefore when the `output-added` signal is emitted, the outputs properties are not yet set. This might break some behaviour in code that relies on that.
- added LsitModel api to the registryy for outputs and seats. Outputs are only added to the list after a `done` event is received, so after its properties have been set, mimicking the old behaviour of the `output-added` signal.
- add an `ASTAL_WL_DISPLAY` environment variable which affects the wayland connection using these values:
    - gdk or gtk: force the use of gdks wayland connection and do not fall back to creating our own
    - astal or any other value: create our own wayland connection and do not use gdks connection
    - unset (default): try to use gdks connection and fallback to creating our own if that fails
 - fix the critical warning if gdk is linked but not initialized
 - add a `roundtrip` and `roundtrip_async` function to allow doing syncs from gjs