### PR TITLE
fix(astal): send correct value signal when change_value is triggered on slider widget

### DIFF
--- a/lib/astal/gtk4/src/widget/slider.vala
+++ b/lib/astal/gtk4/src/widget/slider.vala
@@ -19,6 +19,7 @@ public class Astal.Slider : Gtk.Scale {
             if (this.value == value) {
                 this.notify_property("value");
             }
+            return false;
         });
     }
 


### PR DESCRIPTION
This pull request makes a minor change to the `Astal.Slider` widget. A `return false;` statement was added to the value setter callback to ensure proper signal handling and prevent unintended propagation.