### PR TITLE
fix(notifd): coerce hint accessors

### DIFF
--- a/lib/notifd/src/notification.vala
+++ b/lib/notifd/src/notification.vala
@@ -295,15 +295,27 @@ public class AstalNotifd.Notification : Object {
     }
 
     private string get_str_hint(string name) {
-        return get_hint(name) ? .get_string(null) ?? "";
+        var hint = get_hint(name);
+        // the spec types these hints, but senders get them wrong in
+        // practice: an unchecked accessor logs a GLib critical on every
+        // read, and every state flush re-reads transient
+        if (hint == null || !hint.is_of_type(VariantType.STRING)) return "";
+        return hint.get_string(null) ?? "";
     }
 
     private int32 get_int_hint(string name) {
-        return get_hint(name) ? .get_int32() ?? 0;
+        var hint = get_hint(name);
+        if (hint == null || !hint.is_of_type(VariantType.INT32)) return 0;
+        return hint.get_int32();
     }
 
     private bool get_bool_hint(string name) {
-        return get_hint(name) ? .get_boolean() ?? false;
+        var hint = get_hint(name);
+        if (hint == null) return false;
+        if (hint.is_of_type(VariantType.BOOLEAN)) return hint.get_boolean();
+        // observed in the wild: transient sent as an int32
+        if (hint.is_of_type(VariantType.INT32)) return hint.get_int32() != 0;
+        return false;
     }
 
     internal Notification.deserialize(Variant variant) {

--- a/lib/notifd/src/notification.vala
+++ b/lib/notifd/src/notification.vala
@@ -199,12 +199,11 @@ public class AstalNotifd.Notification : Object {
      */
     public Urgency urgency {
         get {
-            var v = get_hint("urgency");
-            if (v != null) {
-                if (v.get_type_string() == "y") return (Urgency)v.get_byte();
-                if (v.get_type_string() == "x") return (Urgency)v.get_int64();
-            }
-            return Urgency.NORMAL;
+            if (get_hint("urgency") == null) return Urgency.NORMAL;
+            var v = get_int_hint("urgency");
+            if (v < Urgency.LOW) return Urgency.LOW;
+            if (v > Urgency.CRITICAL) return Urgency.CRITICAL;
+            return (Urgency)v;
         }
         set { set_hint("urgency", new Variant.byte(value)); }
     }
@@ -291,31 +290,49 @@ public class AstalNotifd.Notification : Object {
     }
 
     public Variant? get_hint(string name) {
-        return new VariantDict(_hints).lookup_value(name, VariantType.ANY);
+        var hint = new VariantDict(_hints).lookup_value(name, VariantType.ANY);
+        // lookup_value only unwraps the outer variant, but D-Bus allows nesting them
+        while (hint != null && hint.is_of_type(VariantType.VARIANT)) {
+            hint = hint.get_variant();
+        }
+        return hint;
     }
 
     private string get_str_hint(string name) {
         var hint = get_hint(name);
-        // the spec types these hints, but senders get them wrong in
-        // practice: an unchecked accessor logs a GLib critical on every
-        // read, and every state flush re-reads transient
-        if (hint == null || !hint.is_of_type(VariantType.STRING)) return "";
-        return hint.get_string(null) ?? "";
+        if (hint == null) return "";
+        if (
+            hint.is_of_type(VariantType.STRING)
+            || hint.is_of_type(VariantType.OBJECT_PATH)
+            || hint.is_of_type(VariantType.SIGNATURE)
+        ) {
+            return hint.get_string(null) ?? "";
+        }
+        if (hint.is_of_type(VariantType.BYTESTRING)) return hint.get_bytestring() ?? "";
+        return "";
     }
 
     private int32 get_int_hint(string name) {
         var hint = get_hint(name);
-        if (hint == null || !hint.is_of_type(VariantType.INT32)) return 0;
-        return hint.get_int32();
+        if (hint == null) return 0;
+        if (hint.is_of_type(VariantType.INT32)) return hint.get_int32();
+        if (hint.is_of_type(VariantType.UINT32)) return (int32)hint.get_uint32();
+        if (hint.is_of_type(VariantType.BYTE)) return hint.get_byte();
+        if (hint.is_of_type(VariantType.INT16)) return hint.get_int16();
+        if (hint.is_of_type(VariantType.UINT16)) return hint.get_uint16();
+        if (hint.is_of_type(VariantType.INT64)) return (int32)hint.get_int64();
+        if (hint.is_of_type(VariantType.UINT64)) return (int32)hint.get_uint64();
+        if (hint.is_of_type(VariantType.HANDLE)) return hint.get_handle();
+        if (hint.is_of_type(VariantType.DOUBLE)) return (int32)hint.get_double();
+        if (hint.is_of_type(VariantType.BOOLEAN)) return hint.get_boolean() ? 1 : 0;
+        return 0;
     }
 
     private bool get_bool_hint(string name) {
         var hint = get_hint(name);
         if (hint == null) return false;
         if (hint.is_of_type(VariantType.BOOLEAN)) return hint.get_boolean();
-        // observed in the wild: transient sent as an int32
-        if (hint.is_of_type(VariantType.INT32)) return hint.get_int32() != 0;
-        return false;
+        return get_int_hint(name) != 0;
     }
 
     internal Notification.deserialize(Variant variant) {


### PR DESCRIPTION
## Problem

The notification spec types the well-known hints, but senders get them wrong in practice — `transient` sent as an **int32** was observed in the wild (a desktop CLI's notifications).

The unchecked hint accessors then call e.g. `g_variant_get_boolean` on a non-boolean variant, logging a `GLib-CRITICAL` on **every** read. This compounds badly:

- `Daemon.flush_state` re-reads `n.transient` for every notification it persists, so each shell startup replays one critical per restored entry that carries a mistyped hint;
- the criticaling getter reads as `false`, so such notifications are persisted as **non-transient** and keep resurfacing in notification centers — the wrong behavior, not just log noise.

## Fix

Guard all three hint readers (`get_str_hint`, `get_int_hint`, `get_bool_hint`) with `is_of_type`. `get_bool_hint` additionally coerces an int32 (`!= 0`) rather than treating the hint as absent, so `transient: int32 1` still means transient.

Built with meson/ninja: the notifd lib compiles clean.

## Repro

```sh
gdbus call --session --dest org.freedesktop.Notifications   --object-path /org/freedesktop/Notifications   --method org.freedesktop.Notifications.Notify   "test" 0 "" "summary" "body" '[]' "{'transient': <int32 1>}" 1000
```

With an astal-notifd-based daemon running, this logs `g_variant_get_boolean: assertion 'g_variant_is_of_type (value, G_VARIANT_TYPE_BOOLEAN)' failed` at the next state flush (and on every consumer read of `n.transient`). With the patch: silence, and the notification is correctly treated as transient.