### PR TITLE
feat (`astal-wl`): add `ext-idle-notify` support

### DIFF
--- a/lib/wl/idle.vala
+++ b/lib/wl/idle.vala
@@ -1,0 +1,53 @@
+namespace AstalWl {
+/**
+ * Wraps the Wayland `ext_idle_notification_v1` interface.
+ *
+ * An idle notification reports when a [class@AstalWl.Seat] has been inactive
+ * for a given duration and when activity resumes. Instances are created with
+ * [method@AstalWl.Seat.get_idle_notification].
+ */
+public class IdleNotification : Object {
+    private ExtIdleNotificationV1 notification;
+
+    /**
+     * The inactivity duration in milliseconds before this notification idles.
+     */
+    public uint timeout { get; construct; }
+
+    /**
+     * Whether the seat is currently idle.
+     */
+    public bool idle { get; private set; }
+
+    /**
+     * Emitted after the seat has been inactive for the timeout.
+     */
+    public signal void idled();
+
+    /**
+     * Emitted on the first activity after the seat has idled.
+     */
+    public signal void resumed();
+
+    private void handle_idled(ExtIdleNotificationV1 ext_idle_notification_v1) {
+        this.idle = true;
+        idled();
+    }
+
+    private void handle_resumed(ExtIdleNotificationV1 ext_idle_notification_v1) {
+        this.idle = false;
+        resumed();
+    }
+
+    private const ExtIdleNotificationV1Listener notification_listener = {
+        handle_idled,
+        handle_resumed,
+    };
+
+    internal IdleNotification(owned ExtIdleNotificationV1 notification, uint timeout) {
+        Object(timeout: timeout);
+        this.notification = (owned) notification;
+        this.notification.add_listener(notification_listener, this);
+    }
+}
+}

--- a/lib/wl/meson.build
+++ b/lib/wl/meson.build
@@ -48,6 +48,7 @@ wl_protocol_dir = wayland_protos.get_variable(pkgconfig: 'pkgdatadir')
 
 protocols = [
   join_paths(wl_protocol_dir, 'unstable/xdg-output/xdg-output-unstable-v1.xml'),
+  join_paths(wl_protocol_dir, 'staging/ext-idle-notify/ext-idle-notify-v1.xml'),
 ]
 
 protocol_deps = []
@@ -110,6 +111,7 @@ sources = [config] + files(
   'wl-source.vala',
   'output.vala',
   'seat.vala',
+  'idle.vala',
   'utils.vala'
 )
 

--- a/lib/wl/registry.vala
+++ b/lib/wl/registry.vala
@@ -63,6 +63,7 @@ public class Registry : Object {
     private Wl.Registry registry;
     private unowned Wl.Display display;
     private ZxdgOutputManagerV1 output_manager;
+    private ExtIdleNotifierV1 idle_notifier;
 
     private const Wl.RegistryListener registry_listener = {
         registry_handle_global_added,
@@ -206,8 +207,17 @@ public class Registry : Object {
             });
             this.outputs.insert(name, output);
             output_added(output);
+        } else if (@interface == "ext_idle_notifier_v1") {
+            this.idle_notifier = this.registry.bind<ExtIdleNotifierV1>(name, ref ExtIdleNotifierV1.iface, uint.min(version, 2));
+            HashTableIter<uint32, Seat> iter = HashTableIter<uint32, Seat>(this.seats);
+            unowned Seat seat;
+            uint32 id;
+
+            while (iter.next(out id, out seat)) {
+                seat.init_idle(this.idle_notifier);
+            }
         } else if (@interface == "wl_seat") {
-            var seat = new Seat(global, this.registry, this.display);
+            var seat = new Seat(global, this.registry, this.display, this.idle_notifier);
             this.seats.insert(name, seat);
             (this.seat_list_model as ListStore).append(seat);
             seat_added(seat);
@@ -218,7 +228,16 @@ public class Registry : Object {
     private void registry_handle_global_removed(Wl.Registry wl_registry, uint32 name) {
         var global = this.globals.lookup(name);
         this.globals.remove(name);
-        if (global.interface == "wl_output") {
+        if (global.interface == "ext_idle_notifier_v1") {
+            this.idle_notifier = null;
+            HashTableIter<uint32, Seat> iter = HashTableIter<uint32, Seat>(this.seats);
+            unowned Seat seat;
+            uint32 id;
+
+            while (iter.next(out id, out seat)) {
+                seat.init_idle(null);
+            }
+        } else if (global.interface == "wl_output") {
             var output = this.outputs.lookup(name);
             this.outputs.remove(name);
             uint pos;

--- a/lib/wl/seat.vala
+++ b/lib/wl/seat.vala
@@ -21,6 +21,7 @@ public class Seat : Object {
     }
 
     private Wl.Seat seat;
+    private unowned ExtIdleNotifierV1? idle_notifier;
 
     /**
      * Returns the underlying `wl_seat` object.
@@ -57,10 +58,24 @@ public class Seat : Object {
         handle_name,
     };
 
-    internal Seat(Global global, Wl.Registry registry, Wl.Display display) {
+    internal void init_idle(ExtIdleNotifierV1? idle_notifier) {
+        this.idle_notifier = idle_notifier;
+    }
+
+    /**
+     * Creates an [class@AstalWl.IdleNotification] for this seat.
+     */
+    public IdleNotification? get_idle_notification(uint timeout) {
+        if (this.idle_notifier == null) return null;
+        return new IdleNotification(
+            this.idle_notifier.get_idle_notification(timeout, this.seat), timeout);
+    }
+
+    internal Seat(Global global, Wl.Registry registry, Wl.Display display, ExtIdleNotifierV1? idle_notifier) {
         Object(id: global.name);
         this.seat = registry.bind<Wl.Seat>(global.name, ref wl_seat_interface, uint.min(global.version, 10));
         this.seat.add_listener(seat_listener, this);
+        if (idle_notifier != null) init_idle(idle_notifier);
     }
 }
 }


### PR DESCRIPTION
### description

- adds the staging `ext-idle-notify-v1` protocol 
- adds `IdleNotification` that emits `idled` and `resumed`, and tracks an `idle` property.
- integarte with `Seat` and `Registry` 

Related to issue: #473 