### PR TITLE
fix(network)!: group access points and fix security detection

### DIFF
--- a/lib/network/src/accesspoint.vala
+++ b/lib/network/src/accesspoint.vala
@@ -1,9 +1,21 @@
+/**
+ * A wifi network, as one or more NM.AccessPoint that share
+ * an ssid, a mode and a security type.
+ *
+ * A router with a 2.4GHz and a 5GHz radio, or a mesh with several nodes,
+ * advertises one NM.AccessPoint for each radio. They are one network to
+ * the user, so this groups them and reads through to the strongest one.
+ */
 public class AstalNetwork.AccessPoint : Object {
     private Wifi wifi;
-    public NM.AccessPoint ap;
+    private NM.AccessPoint[] aps = {};
+    private ulong[] handlers = {};
+
+    /** The strongest NM.AccessPoint of this network. */
+    public NM.AccessPoint ap { get; private set; }
 
     public uint bandwidth { get { return ap.bandwidth; } }
-    public string bssid { owned get { return ap.bssid; } }
+    public string? bssid { owned get { return ap.bssid; } }
     public uint frequency { get { return ap.frequency; } }
     public int last_seen { get { return ap.last_seen; } }
     public uint max_bitrate { get { return ap.max_bitrate; } }
@@ -14,13 +26,14 @@ public class AstalNetwork.AccessPoint : Object {
     public NM.80211ApSecurityFlags rsn_flags { get { return ap.rsn_flags; } }
     public NM.80211ApSecurityFlags wpa_flags { get { return ap.wpa_flags; } }
 
+    /** How many NM.AccessPoint advertise this network. */
+    public uint access_point_count { get { return aps.length; } }
+
     /**
-     * Security type of this AccessPoint, as negotiated between its
-     * advertised capabilities and those of the wifi device.
+     * Security type of this network, as negotiated between the capabilities
+     * the access points advertise and those of the wifi device.
      */
-    public NM.Utils.SecurityType security {
-        get { return security_type(wifi.device, ap); }
-    }
+    public NM.Utils.SecurityType security { get; private set; }
 
     public GenericArray<NM.RemoteConnection> get_connections() {
         return (GenericArray<NM.RemoteConnection>)ap.filter_connections(
@@ -33,7 +46,7 @@ public class AstalNetwork.AccessPoint : Object {
     }
 
     /**
-     * Whether {@link activate} needs a password for this AccessPoint.
+     * Whether {@link activate} needs a password for this network.
      *
      * Note that enterprise networks need more than a password,
      * so this is `false` for them. See {@link security}.
@@ -63,17 +76,101 @@ public class AstalNetwork.AccessPoint : Object {
     internal AccessPoint(Wifi wifi, NM.AccessPoint ap) {
         this.wifi = wifi;
         this.ap = ap;
+        this.security = security_type(wifi.device, ap);
 
-        ap.notify.connect((pspec) => {
+        add(ap);
+    }
+
+    /**
+     * Whether the given NM.AccessPoint advertises this same network.
+     */
+    internal bool matches(NM.AccessPoint other) {
+        if ((other.ssid == null) || (ap.ssid == null)) return false;
+
+        return ap.ssid.compare(other.ssid) == 0
+            && ap.mode == other.mode
+            && security == security_type(wifi.device, other);
+    }
+
+    internal bool contains(NM.AccessPoint other) {
+        return index_of(other) >= 0;
+    }
+
+    internal bool is_empty {
+        get { return aps.length == 0; }
+    }
+
+    internal void add(NM.AccessPoint member) {
+        if (contains(member)) return;
+
+        aps += member;
+        handlers += member.notify.connect((pspec) => {
+            if (pspec.name == "strength") update_best();
+            if (member != ap) return;
+
             if (get_class().find_property(pspec.name) != null) notify_property(pspec.name);
             if (pspec.name == "strength") icon_name = _icon();
         });
 
+        notify_property("access-point-count");
+        update_best();
+    }
+
+    internal bool remove(NM.AccessPoint member) {
+        var i = index_of(member);
+        if (i < 0) return false;
+
+        aps[i].disconnect(handlers[i]);
+        for (var j = i; j < aps.length - 1; ++j) {
+            aps[j] = aps[j + 1];
+            handlers[j] = handlers[j + 1];
+        }
+        aps.resize(aps.length - 1);
+        handlers.resize(handlers.length - 1);
+
+        notify_property("access-point-count");
+        update_best();
+        return true;
+    }
+
+    private int index_of(NM.AccessPoint member) {
+        for (var i = 0; i < aps.length; ++i) {
+            if (aps[i] == member) return i;
+        }
+        return -1;
+    }
+
+    private void update_best() {
+        NM.AccessPoint? best = null;
+        foreach (var member in aps) {
+            if ((best == null) || (member.strength > best.strength)) best = member;
+        }
+
+        // keep the last known ap when the group is emptied, so that a
+        // consumer holding this object after removal still reads its ssid
+        if ((best == null) || (best == ap)) {
+            icon_name = _icon();
+            return;
+        }
+
+        ap = best;
+
+        // the whole read-through surface now comes from a different ap
+        notify_property("bandwidth");
+        notify_property("bssid");
+        notify_property("frequency");
+        notify_property("last-seen");
+        notify_property("max-bitrate");
+        notify_property("strength");
+        notify_property("mode");
+        notify_property("flags");
+        notify_property("rsn-flags");
+        notify_property("wpa-flags");
         icon_name = _icon();
     }
 
     /**
-     * Activates the first connection associated with this AccessPoint
+     * Activates the first connection associated with this network
      * or creates a new SimpleConnection matching its security type
      * and activates it.
      */
@@ -104,7 +201,7 @@ public class AstalNetwork.AccessPoint : Object {
             var connection = NM.SimpleConnection.new();
 
             // no bssid: pinning the connection to a single bssid stops
-            // NetworkManager from roaming between APs of the same network
+            // NetworkManager from roaming between the aps of this network
             connection.add_setting(new NM.SettingWireless() {
                 ssid = this.ap.ssid,
             });

--- a/lib/network/src/accesspoint.vala
+++ b/lib/network/src/accesspoint.vala
@@ -14,6 +14,14 @@ public class AstalNetwork.AccessPoint : Object {
     public NM.80211ApSecurityFlags rsn_flags { get { return ap.rsn_flags; } }
     public NM.80211ApSecurityFlags wpa_flags { get { return ap.wpa_flags; } }
 
+    /**
+     * Security type of this AccessPoint, as negotiated between its
+     * advertised capabilities and those of the wifi device.
+     */
+    public NM.Utils.SecurityType security {
+        get { return security_type(wifi.device, ap); }
+    }
+
     public GenericArray<NM.RemoteConnection> get_connections() {
         return (GenericArray<NM.RemoteConnection>)ap.filter_connections(
             wifi.device.client.connections
@@ -24,10 +32,23 @@ public class AstalNetwork.AccessPoint : Object {
         return ap.get_path();
     }
 
+    /**
+     * Whether {@link activate} needs a password for this AccessPoint.
+     *
+     * Note that enterprise networks need more than a password,
+     * so this is `false` for them. See {@link security}.
+     */
     public bool requires_password {
         get {
-            return wpa_flags != NM.80211ApSecurityFlags.NONE ||
-                rsn_flags != NM.80211ApSecurityFlags.NONE;
+            switch (security) {
+                case NM.Utils.SecurityType.STATIC_WEP:
+                case NM.Utils.SecurityType.WPA_PSK:
+                case NM.Utils.SecurityType.WPA2_PSK:
+                case NM.Utils.SecurityType.SAE:
+                    return true;
+                default:
+                    return false;
+            }
         }
     }
 
@@ -53,8 +74,8 @@ public class AstalNetwork.AccessPoint : Object {
 
     /**
      * Activates the first connection associated with this AccessPoint
-     * or creates a new SimpleConnection using "wpa-psk" and activates it.
-     * Returns whether the connection is the new active connection.
+     * or creates a new SimpleConnection matching its security type
+     * and activates it.
      */
     public async void activate(string? password = null) throws Error {
         var conns = get_connections();
@@ -64,7 +85,12 @@ public class AstalNetwork.AccessPoint : Object {
 
             if (password != null) {
                 var security = first_conn.get_setting_wireless_security();
-                security.psk = password;
+                if (security == null) {
+                    var setting = security_setting(password);
+                    if (setting != null) first_conn.add_setting(setting);
+                } else {
+                    apply_password(security, password);
+                }
                 yield first_conn.commit_changes_async(true, null);
             }
 
@@ -77,15 +103,14 @@ public class AstalNetwork.AccessPoint : Object {
         } else {
             var connection = NM.SimpleConnection.new();
 
+            // no bssid: pinning the connection to a single bssid stops
+            // NetworkManager from roaming between APs of the same network
             connection.add_setting(new NM.SettingWireless() {
                 ssid = this.ap.ssid,
-                bssid = this.bssid,
             });
 
-            connection.add_setting(new NM.SettingWirelessSecurity() {
-                key_mgmt = "wpa-psk",
-                psk = password,
-            });
+            var setting = security_setting(password);
+            if (setting != null) connection.add_setting(setting);
 
             yield ap.client.add_and_activate_connection_async(
                 connection,
@@ -93,6 +118,89 @@ public class AstalNetwork.AccessPoint : Object {
                 get_path(),
                 null
             );
+        }
+    }
+
+    /**
+     * Returns the best security type the wifi device can use with this ap,
+     * or `INVALID` when the device cannot connect to it at all.
+     */
+    internal static NM.Utils.SecurityType security_type(
+        NM.DeviceWifi device,
+        NM.AccessPoint ap
+    ) {
+        // ordered from strongest to weakest, the first match wins
+        const NM.Utils.SecurityType[] TYPES = {
+            NM.Utils.SecurityType.WPA3_SUITE_B_192,
+            NM.Utils.SecurityType.SAE,
+            NM.Utils.SecurityType.OWE,
+            NM.Utils.SecurityType.WPA2_ENTERPRISE,
+            NM.Utils.SecurityType.WPA2_PSK,
+            NM.Utils.SecurityType.WPA_ENTERPRISE,
+            NM.Utils.SecurityType.WPA_PSK,
+            NM.Utils.SecurityType.DYNAMIC_WEP,
+            NM.Utils.SecurityType.LEAP,
+            NM.Utils.SecurityType.STATIC_WEP,
+            NM.Utils.SecurityType.NONE,
+        };
+
+        var caps = device.wireless_capabilities;
+        var adhoc = ap.mode == NM.80211Mode.ADHOC;
+
+        foreach (var type in TYPES) {
+            var valid = NM.Utils.security_valid(
+                type, caps, true, adhoc, ap.flags, ap.wpa_flags, ap.rsn_flags
+            );
+            if (valid) return type;
+        }
+
+        return NM.Utils.SecurityType.INVALID;
+    }
+
+    private void apply_password(NM.SettingWirelessSecurity security, string password) {
+        if (security.get_key_mgmt() == "none") {
+            security.set_wep_key(0, password);
+        } else {
+            security.psk = password;
+        }
+    }
+
+    private NM.SettingWirelessSecurity? security_setting(string? password) throws Error {
+        switch (security) {
+            case NM.Utils.SecurityType.NONE:
+                return null;
+
+            case NM.Utils.SecurityType.OWE:
+                return new NM.SettingWirelessSecurity() { key_mgmt = "owe" };
+
+            case NM.Utils.SecurityType.STATIC_WEP:
+                return new NM.SettingWirelessSecurity() {
+                    key_mgmt = "none",
+                    wep_key_type = NM.WepKeyType.PASSPHRASE,
+                    wep_key0 = password,
+                };
+
+            case NM.Utils.SecurityType.WPA_PSK:
+            case NM.Utils.SecurityType.WPA2_PSK:
+                return new NM.SettingWirelessSecurity() {
+                    key_mgmt = "wpa-psk",
+                    psk = password,
+                };
+
+            case NM.Utils.SecurityType.SAE:
+                return new NM.SettingWirelessSecurity() {
+                    key_mgmt = "sae",
+                    psk = password,
+                };
+
+            default:
+                // enterprise networks need an 802.1X setting which a password
+                // alone cannot describe, so require an existing profile
+                throw new IOError.NOT_SUPPORTED(
+                    "cannot create a connection for \"%s\": " +
+                    "define a profile for it first, for example with nm-connection-editor",
+                    ssid ?? "unknown network"
+                );
         }
     }
 

--- a/lib/network/src/wifi.vala
+++ b/lib/network/src/wifi.vala
@@ -48,25 +48,15 @@ public class AstalNetwork.Wifi : Object {
         this.device = device;
 
         foreach (var ap in device.access_points) {
-            var new_ap = new AccessPoint(this, ap);
-            _access_points.set(ap.bssid, new_ap);
-            access_point_added(new_ap);
+            add_access_point(ap);
         }
 
         device.access_point_added.connect((access_point) => {
-            var ap = (NM.AccessPoint)access_point;
-            var new_ap = new AccessPoint(this, ap);
-            _access_points.set(ap.bssid, new_ap);
-            access_point_added(new_ap);
-            notify_property("access-points");
+            add_access_point((NM.AccessPoint)access_point);
         });
 
         device.access_point_removed.connect((access_point) => {
-            var ap = (NM.AccessPoint)access_point;
-            var rem_ap = _access_points.get(ap.bssid);
-            _access_points.remove(ap.bssid);
-            access_point_removed(rem_ap);
-            notify_property("access-points");
+            remove_access_point((NM.AccessPoint)access_point);
         });
 
         on_active_connection();
@@ -92,6 +82,36 @@ public class AstalNetwork.Wifi : Object {
         DeviceState old_state,
         NM.DeviceStateReason reaseon
     );
+
+    private void add_access_point(NM.AccessPoint ap) {
+        if (ap.ssid == null) {
+            // NetworkManager creates the AccessPoint before it knows the ssid.
+            // Adding it now would list it as a nameless network, so wait for
+            // the ssid to arrive. A hidden ap never gets one and stays out.
+            ulong id = 0;
+            id = ap.notify["ssid"].connect(() => {
+                if (ap.ssid == null) return;
+                ap.disconnect(id);
+                add_access_point(ap);
+            });
+            return;
+        }
+
+        var new_ap = new AccessPoint(this, ap);
+        _access_points.set(ap.bssid, new_ap);
+        access_point_added(new_ap);
+        notify_property("access-points");
+    }
+
+    private void remove_access_point(NM.AccessPoint ap) {
+        var rem_ap = _access_points.get(ap.bssid);
+        // an ap that never got an ssid was never added
+        if (rem_ap == null) return;
+
+        _access_points.remove(ap.bssid);
+        access_point_removed(rem_ap);
+        notify_property("access-points");
+    }
 
     public void scan() {
         scanning = true;

--- a/lib/network/src/wifi.vala
+++ b/lib/network/src/wifi.vala
@@ -43,7 +43,7 @@ public class AstalNetwork.Wifi : Object {
     public uint8 strength { get; private set; }
     public uint frequency { get; private set; }
     public DeviceState state { get; private set; }
-    public string icon_name { get; private set; }
+    public string? ssid { get; private set; }
     public bool is_hotspot { get; private set; }
     public bool scanning { get; private set; }
 
@@ -183,7 +183,7 @@ public class AstalNetwork.Wifi : Object {
         bandwidth = active_nm_ap.bandwidth;
         frequency = active_nm_ap.frequency;
         strength = active_nm_ap.strength;
-        ssid = active_nm_ap.ssid == null
+        ssid = (active_nm_ap.ssid == null)
             ? null
             : (string)NM.Utils.ssid_to_utf8(active_nm_ap.ssid.get_data());
     }

--- a/lib/network/src/wifi.vala
+++ b/lib/network/src/wifi.vala
@@ -11,8 +11,7 @@ public class AstalNetwork.Wifi : Object {
     internal const string ICON_NO_ROUTE = "network-wireless-no-route-symbolic";
     internal const string ICON_HOTSPOT = "network-wireless-hotspot-symbolic";
 
-    private HashTable<string, AccessPoint> _access_points =
-        new HashTable<string, AccessPoint>(str_hash, str_equal);
+    private GenericArray<AccessPoint> _access_points = new GenericArray<AccessPoint>();
 
     public NM.DeviceWifi device { get; construct set; }
 
@@ -20,10 +19,17 @@ public class AstalNetwork.Wifi : Object {
     private ulong connection_handler = 0;
 
     public AccessPoint? active_access_point { get; private set; }
+    private NM.AccessPoint? active_nm_ap = null;
     private ulong ap_handler = 0;
 
     public List<weak AccessPoint> access_points {
-        owned get { return _access_points.get_values(); }
+        owned get {
+            var list = new List<weak AccessPoint>();
+            foreach (var ap in _access_points) {
+                list.append(ap);
+            }
+            return list;
+        }
     }
 
     public bool enabled {
@@ -97,20 +103,36 @@ public class AstalNetwork.Wifi : Object {
             return;
         }
 
+        // one router advertises one ap per radio and a mesh one per node.
+        // they are one network to the user, so group them.
+        foreach (var group in _access_points) {
+            if (group.matches(ap)) {
+                group.add(ap);
+                resolve_active_access_point();
+                return;
+            }
+        }
+
         var new_ap = new AccessPoint(this, ap);
-        _access_points.set(ap.bssid, new_ap);
+        _access_points.add(new_ap);
         access_point_added(new_ap);
         notify_property("access-points");
+        resolve_active_access_point();
     }
 
     private void remove_access_point(NM.AccessPoint ap) {
-        var rem_ap = _access_points.get(ap.bssid);
-        // an ap that never got an ssid was never added
-        if (rem_ap == null) return;
+        for (var i = 0; i < _access_points.length; ++i) {
+            var group = _access_points.get(i);
+            // an ap that never got an ssid was never added to any group
+            if (!group.remove(ap)) continue;
 
-        _access_points.remove(ap.bssid);
-        access_point_removed(rem_ap);
-        notify_property("access-points");
+            if (group.is_empty) {
+                _access_points.remove_index(i);
+                access_point_removed(group);
+                notify_property("access-points");
+            }
+            return;
+        }
     }
 
     public void scan() {
@@ -156,25 +178,48 @@ public class AstalNetwork.Wifi : Object {
     }
 
     private void on_active_access_point_notify() {
-        bandwidth = active_access_point.bandwidth;
-        frequency = active_access_point.frequency;
-        strength = active_access_point.strength;
-        ssid = active_access_point.ssid;
+        if (active_nm_ap == null) return;
+
+        bandwidth = active_nm_ap.bandwidth;
+        frequency = active_nm_ap.frequency;
+        strength = active_nm_ap.strength;
+        ssid = active_nm_ap.ssid == null
+            ? null
+            : (string)NM.Utils.ssid_to_utf8(active_nm_ap.ssid.get_data());
     }
 
     private void on_active_access_point() {
-        if ((ap_handler > 0) && (active_access_point != null)) {
-            active_access_point.disconnect(ap_handler);
+        if ((ap_handler > 0) && (active_nm_ap != null)) {
+            active_nm_ap.disconnect(ap_handler);
             ap_handler = 0;
-            active_access_point = null;
         }
 
-        var ap = device.active_access_point;
-        if (ap != null) {
-            active_access_point = _access_points.get(ap.bssid);
-            on_active_access_point_notify();
-            ap_handler = active_access_point.notify.connect(on_active_access_point_notify);
+        active_nm_ap = device.active_access_point;
+        resolve_active_access_point();
+        on_active_access_point_notify();
+
+        if (active_nm_ap != null) {
+            ap_handler = active_nm_ap.notify.connect(on_active_access_point_notify);
         }
+    }
+
+    // points active_access_point at the group holding the active ap.
+    // the group can appear after the active ap does, because an ap without
+    // an ssid yet waits before it joins one.
+    private void resolve_active_access_point() {
+        if (active_nm_ap == null) {
+            active_access_point = null;
+            return;
+        }
+
+        foreach (var group in _access_points) {
+            if (group.contains(active_nm_ap)) {
+                active_access_point = group;
+                return;
+            }
+        }
+
+        active_access_point = null;
     }
 
     private string _icon() {


### PR DESCRIPTION
## Problem

Access points are keyed by BSSID with no SSID filtering, so a scan of 20 APs lists 20 rows — 3 nameless "unknown network" and 4 duplicates — where `nmcli` and gnome-shell show 13.

## Approach
- Defer an `AccessPoint` until `notify::ssid` fires. NetworkManager creates it before the SSID is known, and a hidden AP never gets one. Same as gnome-shell's `_addAccessPoint`.
- Use `nm_utils_security_valid()` instead of reading `wpa_flags`/`rsn_flags`, exposed as a new `AccessPoint.security`. The flag check reported WEP as open and OWE as needing a password.
- Derive `key_mgmt` from that type. `activate()` hardcoded `wpa-psk`, so it could not connect to WEP, WPA3-SAE, OWE or enterprise at all.
- Drop `bssid` from the new `SettingWireless`, which pinned the connection to one radio and blocked roaming.

- `Wifi.access_points` holds one entry per (ssid, mode, security), reading through to the strongest member, like gnome-shell's `WirelessNetwork`. Adds `access_point_count`; `bssid` is the strongest member's and is now nullable.
- `Wifi.strength`, `frequency` and `bandwidth` still report the AP actually in use, so the icon does not regress on a mesh.

## Verification

libnm 1.56.1 against live NetworkManager, compared with `nmcli` in the same process:

```
nmcli : 20 APs, 3 hidden, 13 named
astal : 20 device APs -> 13 entries, 0 nameless, names match nmcli exactly
```

Rescan groups correctly and resets `scanning`, with no criticals under `G_DEBUG=fatal-criticals`.