### PR TITLE
fix(bluetooth): async D-Bus calls and adapter state

### DIFF
--- a/lib/bluetooth/src/adapter.vala
+++ b/lib/bluetooth/src/adapter.vala
@@ -2,9 +2,22 @@
  * Object representing an [[https://github.com/RadiusNetworks/bluez/blob/master/doc/adapter-api.txt|adapter]].
  */
 public class AstalBluetooth.Adapter : Object {
+    /**
+     * Seconds to wait for a power change to take effect before giving up
+     * on the transition. Toggling an adapter goes through rfkill, which on
+     * some systems takes a noticeable while, and can fail without a reply.
+     */
+    private const uint STATE_TIMEOUT = 30;
+
     private IAdapter proxy;
+    private uint state_timeout = 0;
 
     internal string object_path { owned get; private set; }
+
+    /**
+     * State of this adapter, including the transitions between on and off.
+     */
+    public AdapterState state { get; private set; default = AdapterState.OFF; }
 
     internal Adapter(IAdapter proxy) {
         this.proxy = proxy;
@@ -16,8 +29,25 @@ public class AstalBluetooth.Adapter : Object {
                 if (get_class().find_property(prop) != null) {
                     notify_property(prop);
                 }
+
+                if (prop == "powered") settle_state();
             }
         });
+
+        settle_state();
+    }
+
+    ~Adapter() {
+        if (state_timeout > 0) Source.remove(state_timeout);
+    }
+
+    private void settle_state() {
+        if (state_timeout > 0) {
+            Source.remove(state_timeout);
+            state_timeout = 0;
+        }
+
+        state = proxy.powered ? AdapterState.ON : AdapterState.OFF;
     }
 
     /**
@@ -72,7 +102,21 @@ public class AstalBluetooth.Adapter : Object {
      */
     public bool powered {
         get { return proxy.powered; }
-        set { proxy.powered = value; }
+        set {
+            if (value == proxy.powered) return;
+
+            state = value ? AdapterState.TURNING_ON : AdapterState.TURNING_OFF;
+
+            // the transition has to end even if the adapter never reports back
+            if (state_timeout > 0) Source.remove(state_timeout);
+            state_timeout = Timeout.add_seconds(STATE_TIMEOUT, () => {
+                state_timeout = 0;
+                state = proxy.powered ? AdapterState.ON : AdapterState.OFF;
+                return Source.REMOVE;
+            });
+
+            proxy.powered = value;
+        }
     }
 
     /**
@@ -133,5 +177,31 @@ public class AstalBluetooth.Adapter : Object {
      */
     public async void stop_discovery() throws Error {
         yield proxy.stop_discovery();
+    }
+}
+
+/**
+ * State of an [class@AstalBluetooth.Adapter].
+ */
+public enum AstalBluetooth.AdapterState {
+    /** No adapter is present. */
+    ABSENT,
+    /** The adapter is not powered. */
+    OFF,
+    /** The adapter is powered. */
+    ON,
+    /** The adapter is powering on. */
+    TURNING_ON,
+    /** The adapter is powering off. */
+    TURNING_OFF;
+
+    public string to_string() {
+        switch (this) {
+            case OFF: return "off";
+            case ON: return "on";
+            case TURNING_ON: return "turning_on";
+            case TURNING_OFF: return "turning_off";
+            default: return "absent";
+        }
     }
 }

--- a/lib/bluetooth/src/adapter.vala
+++ b/lib/bluetooth/src/adapter.vala
@@ -113,8 +113,8 @@ public class AstalBluetooth.Adapter : Object {
      *
      * Possible errors: `InvalidArguments`, `Failed`.
      */
-    public void remove_device(Device device) throws Error {
-        proxy.remove_device(device.object_path);
+    public async void remove_device(Device device) throws Error {
+        yield proxy.remove_device(device.object_path);
     }
 
     /**
@@ -122,8 +122,8 @@ public class AstalBluetooth.Adapter : Object {
      *
      * Possible errors: `NotReady`, `Failed`.
      */
-    public void start_discovery() throws Error {
-        proxy.start_discovery();
+    public async void start_discovery() throws Error {
+        yield proxy.start_discovery();
     }
 
     /**
@@ -131,7 +131,7 @@ public class AstalBluetooth.Adapter : Object {
      *
      * Possible errors: `NotReady`, `Failed`, `NotAuthorized`.
      */
-    public void stop_discovery() throws Error {
-        proxy.stop_discovery();
+    public async void stop_discovery() throws Error {
+        yield proxy.stop_discovery();
     }
 }

--- a/lib/bluetooth/src/bluetooth.vala
+++ b/lib/bluetooth/src/bluetooth.vala
@@ -11,6 +11,11 @@ public Bluetooth get_default() {
  * Manager object for `org.bluez`.
  */
 public class AstalBluetooth.Bluetooth : Object {
+    // one icon per state, each named after the state it represents
+    internal const string ICON_ACTIVE = "bluetooth-active-symbolic";
+    internal const string ICON_DISCONNECTED = "bluetooth-disconnected-symbolic";
+    internal const string ICON_DISABLED = "bluetooth-disabled-symbolic";
+
     private static Bluetooth _instance;
 
     /**
@@ -68,6 +73,14 @@ public class AstalBluetooth.Bluetooth : Object {
     public bool is_connected { get; private set; default = false; }
 
     /**
+     * Symbolic icon name for the current state:
+     * `bluetooth-disabled-symbolic` when no adapter is powered,
+     * `bluetooth-active-symbolic` when a device is connected, and
+     * `bluetooth-disconnected-symbolic` when powered with nothing connected.
+     */
+    public string icon_name { get; private set; default = ICON_DISABLED; }
+
+    /**
      * The first registered adapter which is usually the only adapter.
      */
     public Adapter? adapter { get { return adapters.nth_data(0); } }
@@ -98,19 +111,13 @@ public class AstalBluetooth.Bluetooth : Object {
             );
 
             foreach (var object in manager.get_objects()) {
-                foreach (var iface in object.get_interfaces()) {
-                    on_interface_added(object, iface);
-                }
+                add_object(object);
             }
 
             manager.interface_added.connect(on_interface_added);
             manager.interface_removed.connect(on_interface_removed);
 
-            manager.object_added.connect((object) => {
-                foreach (var iface in object.get_interfaces()) {
-                    on_interface_added(object, iface);
-                }
-            });
+            manager.object_added.connect(add_object);
 
             manager.object_removed.connect((object) => {
                 foreach (var iface in object.get_interfaces()) {
@@ -152,6 +159,25 @@ public class AstalBluetooth.Bluetooth : Object {
             default:
                 return typeof(DBusProxy);
         }
+    }
+
+    /**
+     * Adds every interface of an object, devices and adapters first.
+     * A Battery1 handled before its Device1 would find no device to attach to.
+     */
+    private void add_object(DBusObject object) {
+        var interfaces = object.get_interfaces();
+        interfaces.sort((a, b) => rank(b) - rank(a));
+
+        foreach (var iface in interfaces) {
+            on_interface_added(object, iface);
+        }
+    }
+
+    private static int rank(DBusInterface iface) {
+        if (iface is IAdapter) return 2;
+        if (iface is IDevice) return 2;
+        return 1;
     }
 
     private void on_interface_added(DBusObject object, DBusInterface iface) {
@@ -196,6 +222,11 @@ public class AstalBluetooth.Bluetooth : Object {
             adapter_removed(adapter_obj);
         }
 
+        if (iface is IBattery) {
+            var device = _devices.lookup(iface.g_object_path);
+            if (device != null) device.set_battery(null);
+        }
+
         sync();
     }
 
@@ -211,6 +242,14 @@ public class AstalBluetooth.Bluetooth : Object {
             if (connected != is_connected) {
                 is_connected = connected;
             }
+        }
+
+        if (!powered) {
+            icon_name = ICON_DISABLED;
+        } else if (connected) {
+            icon_name = ICON_ACTIVE;
+        } else {
+            icon_name = ICON_DISCONNECTED;
         }
     }
 

--- a/lib/bluetooth/src/bluetooth.vala
+++ b/lib/bluetooth/src/bluetooth.vala
@@ -15,6 +15,7 @@ public class AstalBluetooth.Bluetooth : Object {
     internal const string ICON_ACTIVE = "bluetooth-active-symbolic";
     internal const string ICON_DISCONNECTED = "bluetooth-disconnected-symbolic";
     internal const string ICON_DISABLED = "bluetooth-disabled-symbolic";
+    internal const string ICON_ACQUIRING = "bluetooth-acquiring-symbolic";
 
     private static Bluetooth _instance;
 
@@ -79,6 +80,12 @@ public class AstalBluetooth.Bluetooth : Object {
      * `bluetooth-disconnected-symbolic` when powered with nothing connected.
      */
     public string icon_name { get; private set; default = ICON_DISABLED; }
+
+    /**
+     * State of the [property@AstalBluetooth.Bluetooth:adapter],
+     * or `ABSENT` when there is no adapter.
+     */
+    public AdapterState adapter_state { get; private set; default = AdapterState.ABSENT; }
 
     /**
      * The first registered adapter which is usually the only adapter.
@@ -244,7 +251,12 @@ public class AstalBluetooth.Bluetooth : Object {
             }
         }
 
-        if (!powered) {
+        adapter_state = adapter == null ? AdapterState.ABSENT : adapter.state;
+
+        if ((adapter_state == AdapterState.TURNING_ON)
+            || (adapter_state == AdapterState.TURNING_OFF)) {
+            icon_name = ICON_ACQUIRING;
+        } else if (!powered) {
             icon_name = ICON_DISABLED;
         } else if (connected) {
             icon_name = ICON_ACTIVE;

--- a/lib/bluetooth/src/device.vala
+++ b/lib/bluetooth/src/device.vala
@@ -17,17 +17,29 @@ public class AstalBluetooth.Device : Object {
                 if (get_class().find_property(prop) != null) {
                     notify_property(prop);
                 }
+
+                if (prop == "icon") notify_property("icon-name");
             }
         });
     }
 
-    internal void set_battery(Battery battery) {
+    private ulong battery_handler = 0;
+
+    internal void set_battery(Battery? battery) {
+        if ((battery_handler > 0) && (this.battery != null)) {
+            this.battery.disconnect(battery_handler);
+            battery_handler = 0;
+        }
+
         this.battery = battery;
 
+        if (battery != null) {
+            battery_handler = battery.notify["percentage"].connect(() => {
+                notify_property("battery_percentage");
+            });
+        }
+
         notify_property("battery_percentage");
-        battery.notify["percentage"].connect((obj, pspec) => {
-            notify_property("battery_percentage");
-        });
     }
 
     /**
@@ -96,6 +108,19 @@ public class AstalBluetooth.Device : Object {
      * Indicates if this device is currently trying to be connected.
      */
     public bool connecting { get; private set; }
+
+    /**
+     * Symbolic icon name for this device, based on
+     * [property@AstalBluetooth.Device:icon].
+     */
+    public string icon_name {
+        owned get {
+            var name = proxy.icon;
+            if (name == null) return "bluetooth-symbolic";
+
+            return name + "-symbolic";
+        }
+    }
 
     /**
      * If set to `true` any incoming connections from the device will be immediately rejected.
@@ -168,8 +193,8 @@ public class AstalBluetooth.Device : Object {
      *
      * @param uuid the remote service UUID.
      */
-    public void connect_profile(string uuid) throws Error {
-        proxy.connect_profile(uuid);
+    public async void connect_profile(string uuid) throws Error {
+        yield proxy.connect_profile(uuid);
     }
 
     /**
@@ -179,8 +204,8 @@ public class AstalBluetooth.Device : Object {
      *
      * @param uuid the remote service UUID.
      */
-    public void disconnect_profile(string uuid) throws Error {
-        proxy.disconnect_profile(uuid);
+    public async void disconnect_profile(string uuid) throws Error {
+        yield proxy.disconnect_profile(uuid);
     }
 
     /**
@@ -190,8 +215,8 @@ public class AstalBluetooth.Device : Object {
      * `AuthenticationCanceled`, `AuthenticationFailed`, `AuthenticationRejected`,
      * `AuthenticationTimeout`, `ConnectionAttemptFailed`.
      */
-    public void pair() throws Error {
-        proxy.pair();
+    public async void pair() throws Error {
+        yield proxy.pair();
     }
 
     /**
@@ -200,7 +225,7 @@ public class AstalBluetooth.Device : Object {
      *
      * Possible errors: `DoesNotExist`, `Failed`.
      */
-    public void cancel_pairing() throws Error {
-        proxy.cancel_pairing();
+    public async void cancel_pairing() throws Error {
+        yield proxy.cancel_pairing();
     }
 }

--- a/lib/bluetooth/src/interfaces.vala
+++ b/lib/bluetooth/src/interfaces.vala
@@ -1,8 +1,8 @@
 [DBus(name = "org.bluez.Adapter1")]
 private interface AstalBluetooth.IAdapter : DBusProxy {
-    public abstract void remove_device(ObjectPath device) throws Error;
-    public abstract void start_discovery() throws Error;
-    public abstract void stop_discovery() throws Error;
+    public abstract async void remove_device(ObjectPath device) throws Error;
+    public abstract async void start_discovery() throws Error;
+    public abstract async void stop_discovery() throws Error;
 
     public abstract string[] uuids { owned get; }
     public abstract bool discoverable { get; set; }
@@ -20,12 +20,12 @@ private interface AstalBluetooth.IAdapter : DBusProxy {
 
 [DBus(name = "org.bluez.Device1")]
 private interface AstalBluetooth.IDevice : DBusProxy {
-    public abstract void cancel_pairing() throws Error;
+    public abstract async void cancel_pairing() throws Error;
     public abstract async void connect() throws Error;
-    public abstract void connect_profile(string uuid) throws Error;
+    public abstract async void connect_profile(string uuid) throws Error;
     public abstract async void disconnect() throws Error;
-    public abstract void disconnect_profile(string uuid) throws Error;
-    public abstract void pair() throws Error;
+    public abstract async void disconnect_profile(string uuid) throws Error;
+    public abstract async void pair() throws Error;
 
     public abstract string[] uuids { owned get; }
     public abstract bool blocked { get; set; }


### PR DESCRIPTION
## Problem

- Seven `org.bluez` methods were synchronous, each blocking the main loop for a full D-Bus round trip. `pair` is the worst, since it waits on the user.
- A device never released its battery: `on_interface_removed` handled `IDevice` and `IAdapter` but not `IBattery`, so `battery_percentage` kept reporting a stale value after a disconnect. `set_battery` also connected `notify::percentage` on every call without disconnecting the previous handler.
- A `Battery1` handled before its `Device1` finds no device to attach to and is dropped. #388 fixes the startup pass only and leaves `object-added` unsorted, so a device appearing later still loses its battery.
- `powered` was a bare boolean, so a consumer could not tell a settled adapter from one still switching, and there was no icon at all.
- Closes #137.

## Approach

1. the seven methods become async; removing `IBattery` clears the battery and disconnects its handler; one ordered interface walk shared by startup and `object-added`, devices and adapters first.
2. `Bluetooth.icon_name`, one icon per state: disabled, active, disconnected.
3. `AdapterState` with `ABSENT`, `OFF`, `ON`, `TURNING_ON`, `TURNING_OFF`

## Verification

Live BlueZ, the same call before and after:

```
before: returned in 0.112s, main loop iterated 0x   (blocked)
after : returned in 0.114s, main loop iterated 11x  (responsive)
```
