### PR TITLE
fix(tray): handle combined service and object path in StatusNotifierWatcher

### DIFF
--- a/lib/tray/src/watcher.vala
+++ b/lib/tray/src/watcher.vala
@@ -46,6 +46,10 @@ internal class StatusNotifierWatcher : Object {
         if (service[0] == '/') {
             path = service;
             busName = sender;
+        } else if (service.contains("/")) {
+            var parts = service.split("/", 2);
+            busName = parts[0];
+            path = "/" + parts[1];
         } else {
             busName = service;
             path = "/StatusNotifierItem";


### PR DESCRIPTION
### Summary

Some StatusNotifierItem implementations (most notably Chromium and Electron applications such as Element, Slack, Discord, etc.) register against `org.kde.StatusNotifierWatcher` using a combined bus name and object path string formatted like:
`org.freedesktop.StatusNotifierItem-<PID>-<ID>/StatusNotifierItem/<ID>`

Previously, `RegisterStatusNotifierItem` in `watcher.vala` only checked whether `service[0] == '/'`. If it did not start with `/`, it assumed the string was solely a bus name and unconditionally appended `/StatusNotifierItem`.

This produced malformed paths like:
`org.freedesktop.StatusNotifierItem-.../StatusNotifierItem/1/StatusNotifierItem`

Because `TrayItem` attempts to read DBus properties and menu models from that path, and Chromium only exposes `/StatusNotifierItem/1`, all properties (`id`, `title`, `gicon`, `menu_model`, `action_group`) resolved to `null`, resulting in an empty non-interactive tray icon.

### Solution

Check if `service` contains a `/` and split the bus name and object path accordingly:
- If `service` starts with `/`: sender is bus name, `service` is path
- If `service` contains `/`: split on first `/` into bus name and path
- Otherwise: `service` is bus name, default path is `/StatusNotifierItem`