### PR TITLE
fix(AstalHyprland): stop reading after socket EOF

### DIFF
--- a/lib/hyprland/src/hyprland.vala
+++ b/lib/hyprland/src/hyprland.vala
@@ -138,6 +138,9 @@ public class Hyprland : Object {
         stream.read_line_async.begin(Priority.DEFAULT, null, (_, res) => {
                 try {
                     var line = stream.read_line_async.end(res);
+                    if (line == null) {
+                        return;
+                    }
                     handle_event.begin(line, (_, res) => {
                         try {
                             handle_event.end(res);


### PR DESCRIPTION
When the Hyprland event socket closes, `read_line_async()` returns `null`. AstalHyprland passed that value to `handle_event()` and immediately scheduled another read, causing a tight loop that saturated the GJS process and flooded the journal with `line != NULL` assertions.

This adds an EOF guard and stops watching the closed stream.

Tested:
- built `lib/hyprland` with Meson and the system C compiler
- ran AGS against the rebuilt library for 28+ seconds
- confirmed no `line != NULL` assertions and no CPU spinloop

The existing socket reconnect behavior is unchanged; this only prevents the closed-stream loop.