### PR TITLE
chore(idle-notify): fix typos in docs and comments

### DIFF
--- a/docs/guide/libraries/idle-notify.md
+++ b/docs/guide/libraries/idle-notify.md
@@ -1,6 +1,6 @@
 # IdleNotify
 
-Library implementing the `ext-idle-notifier-v1` wayland protocol.
+Library implementing the `ext-idle-notify-v1` wayland protocol.
 
 ## Usage
 

--- a/lib/idle-notify/src/notifier.vala
+++ b/lib/idle-notify/src/notifier.vala
@@ -15,7 +15,7 @@ public class Notifier : Object {
     private static Notifier? instance;
 
     /**
-     * Gets the degault singleton Notifier instance
+     * Gets the default singleton Notifier instance
      */
     public static unowned Notifier get_default() {
         if (instance == null) instance = new Notifier();
@@ -26,7 +26,7 @@ public class Notifier : Object {
     private ExtIdleNotifierV1 notifier;
 
     /**
-     * Creates a notifiication object with the given timeout for a given seat. It will notify when the seat is inactive
+     * Creates a notification object with the given timeout for a given seat. It will notify when the seat is inactive
      * for at least the provided timeout.
      */
     public Notification get_idle_notification_for_seat(uint timeout, AstalWl.Seat seat) {
@@ -36,7 +36,7 @@ public class Notifier : Object {
     }
     
     /**
-     * Creates a notifiication object with the given timeout for the first available seat. It will notify when the seat is inactive
+     * Creates a notification object with the given timeout for the first available seat. It will notify when the seat is inactive
      * for at least the provided timeout.
      */
     public Notification get_idle_notification(uint timeout) {
@@ -44,8 +44,8 @@ public class Notifier : Object {
     }
 
     /**
-     * Creates a notifiication object with the given output for a given seat. It will notify when the input is inactive
-     * for at least the provided timeout. Because this track the user input, it will ignore registered idle inhibtors.
+     * Creates a notification object with the given output for a given seat. It will notify when the input is inactive
+     * for at least the provided timeout. Because this track the user input, it will ignore registered idle inhibitors.
      */
     public Notification get_input_idle_notification_for_seat(uint timeout, AstalWl.Seat seat) {
         assert(this.notifier != null);
@@ -55,8 +55,8 @@ public class Notifier : Object {
     }
     
     /**
-     * Creates a notifiication object with the given output for the first available seat. It will notify when the input is inactive
-     * for at least the provided timeout. Because this track the user input, it will ignore registered idle inhibtors.
+     * Creates a notification object with the given output for the first available seat. It will notify when the input is inactive
+     * for at least the provided timeout. Because this track the user input, it will ignore registered idle inhibitors.
      */
     public Notification get_input_idle_notification(uint timeout) {
         return this.get_input_idle_notification_for_seat(timeout, this.astal_registry.get_seats().nth_data(0));


### PR DESCRIPTION
Some typos from recent PR. And the name of the protocol is …-notify. https://wayland.app/protocols/ext-idle-notify-v1

However, I understand that maybe -notifier, is the way to, I'll change it if needed.